### PR TITLE
[FIX] report parser check to use "scale"

### DIFF
--- a/drivers/FGRGBWM-441/driver.js
+++ b/drivers/FGRGBWM-441/driver.js
@@ -124,12 +124,12 @@ module.exports = new ZwaveDriver( path.basename(__dirname), {
 			},
 			'command_report': 'METER_REPORT',
 			'command_report_parser': report => {
-				if (report.hasOwnProperty('Properties2') &&
-					report.Properties2.hasOwnProperty('Scale') &&
-					report.Properties2['Scale'] !== 2)
-					return null;
-				
-				return report['Meter Value (Parsed)'];
+				if (report.hasOwnProperty('Properties1') &&
+				report.Properties1.hasOwnProperty('Scale') &&
+				report.Properties1['Scale'] === 2)
+					return report['Meter Value (Parsed)'];
+					
+				return null;
 			}
 		},
 		
@@ -145,12 +145,12 @@ module.exports = new ZwaveDriver( path.basename(__dirname), {
 			},
 			'command_report': 'METER_REPORT',
 			'command_report_parser': report => {
-				if (report.hasOwnProperty('Properties2') &&
-					report.Properties2.hasOwnProperty('Scale') &&
-					report.Properties2['Scale'] !== 2)
-					return null;
+				if (report.hasOwnProperty('Properties1') &&
+				report.Properties1.hasOwnProperty('Scale') &&
+				report.Properties1['Scale'] === 0)
+					return report['Meter Value (Parsed)'];
 				
-				return report['Meter Value (Parsed)'];
+				return null;
 			}
 		}
 	},

--- a/drivers/FGS-213/driver.js
+++ b/drivers/FGS-213/driver.js
@@ -33,12 +33,12 @@ module.exports = new ZwaveDriver( path.basename(__dirname), {
 			},
 			'command_report': 'METER_REPORT',
 			'command_report_parser': report => {
-				if (report.hasOwnProperty('Properties2') &&
-					report.Properties2.hasOwnProperty('Scale bits 10') &&
-					report.Properties2['Scale bits 10'] !== 2)
-					return null;
-				
-				return report['Meter Value (Parsed)'];
+				if (report.hasOwnProperty('Properties1') &&
+				report.Properties1.hasOwnProperty('Scale') &&
+				report.Properties1['Scale'] === 2)
+					return report['Meter Value (Parsed)'];
+					
+				return null;
 			}
 		},
 		
@@ -54,12 +54,12 @@ module.exports = new ZwaveDriver( path.basename(__dirname), {
 			},
 			'command_report': 'METER_REPORT',
 			'command_report_parser': report => {
-				if (report.hasOwnProperty('Properties2') &&
-					report.Properties2.hasOwnProperty('Scale bits 10') &&
-					report.Properties2['Scale bits 10'] !== 2)
-					return null;
+				if (report.hasOwnProperty('Properties1') &&
+				report.Properties1.hasOwnProperty('Scale') &&
+				report.Properties1['Scale'] === 0)
+					return report['Meter Value (Parsed)'];
 				
-				return report['Meter Value (Parsed)'];
+				return null;
 			}
 		}
 	},

--- a/drivers/FGS-223/driver.js
+++ b/drivers/FGS-223/driver.js
@@ -33,12 +33,12 @@ module.exports = new ZwaveDriver( path.basename(__dirname), {
 			},
 			'command_report': 'METER_REPORT',
 			'command_report_parser': report => {
-				if (report.hasOwnProperty('Properties2') &&
-					report.Properties2.hasOwnProperty('Scale bits 10') &&
-					report.Properties2['Scale bits 10'] !== 0)
-					return null;
-				
-				return report['Meter Value (Parsed)'];
+				if (report.hasOwnProperty('Properties1') &&
+				report.Properties1.hasOwnProperty('Scale') &&
+				report.Properties1['Scale'] === 2)
+					return report['Meter Value (Parsed)'];
+					
+				return null;
 			}
 		},
 		
@@ -54,12 +54,12 @@ module.exports = new ZwaveDriver( path.basename(__dirname), {
 			},
 			'command_report': 'METER_REPORT',
 			'command_report_parser': report => {
-				if (report.hasOwnProperty('Properties2') &&
-					report.Properties2.hasOwnProperty('Scale bits 10') &&
-					report.Properties2['Scale bits 10'] !== 0)
-					return null;
+				if (report.hasOwnProperty('Properties1') &&
+				report.Properties1.hasOwnProperty('Scale') &&
+				report.Properties1['Scale'] === 0)
+					return report['Meter Value (Parsed)'];
 				
-				return report['Meter Value (Parsed)'];
+				return null;
 			}
 		}
 	},


### PR DESCRIPTION
"scale bits 10" is for both "measure_power & meter_power) 2, so it will use the last capability in list "meter_power" for both values.
now changed to "scale" which is different for both measure_power and meter_power capabilities

fgrgbw was using the wrong parser, now using a proper one (same as FGS-2*3), added that to this PR