### PR TITLE
Revert "[FIX] report parser check to use "scale""

### DIFF
--- a/drivers/FGRGBWM-441/driver.js
+++ b/drivers/FGRGBWM-441/driver.js
@@ -124,12 +124,12 @@ module.exports = new ZwaveDriver( path.basename(__dirname), {
 			},
 			'command_report': 'METER_REPORT',
 			'command_report_parser': report => {
-				if (report.hasOwnProperty('Properties1') &&
-				report.Properties1.hasOwnProperty('Scale') &&
-				report.Properties1['Scale'] === 2)
-					return report['Meter Value (Parsed)'];
-					
-				return null;
+				if (report.hasOwnProperty('Properties2') &&
+					report.Properties2.hasOwnProperty('Scale') &&
+					report.Properties2['Scale'] !== 2)
+					return null;
+				
+				return report['Meter Value (Parsed)'];
 			}
 		},
 		
@@ -145,12 +145,12 @@ module.exports = new ZwaveDriver( path.basename(__dirname), {
 			},
 			'command_report': 'METER_REPORT',
 			'command_report_parser': report => {
-				if (report.hasOwnProperty('Properties1') &&
-				report.Properties1.hasOwnProperty('Scale') &&
-				report.Properties1['Scale'] === 0)
-					return report['Meter Value (Parsed)'];
+				if (report.hasOwnProperty('Properties2') &&
+					report.Properties2.hasOwnProperty('Scale') &&
+					report.Properties2['Scale'] !== 2)
+					return null;
 				
-				return null;
+				return report['Meter Value (Parsed)'];
 			}
 		}
 	},

--- a/drivers/FGS-213/driver.js
+++ b/drivers/FGS-213/driver.js
@@ -33,12 +33,12 @@ module.exports = new ZwaveDriver( path.basename(__dirname), {
 			},
 			'command_report': 'METER_REPORT',
 			'command_report_parser': report => {
-				if (report.hasOwnProperty('Properties1') &&
-				report.Properties1.hasOwnProperty('Scale') &&
-				report.Properties1['Scale'] === 2)
-					return report['Meter Value (Parsed)'];
-					
-				return null;
+				if (report.hasOwnProperty('Properties2') &&
+					report.Properties2.hasOwnProperty('Scale bits 10') &&
+					report.Properties2['Scale bits 10'] !== 2)
+					return null;
+				
+				return report['Meter Value (Parsed)'];
 			}
 		},
 		
@@ -54,12 +54,12 @@ module.exports = new ZwaveDriver( path.basename(__dirname), {
 			},
 			'command_report': 'METER_REPORT',
 			'command_report_parser': report => {
-				if (report.hasOwnProperty('Properties1') &&
-				report.Properties1.hasOwnProperty('Scale') &&
-				report.Properties1['Scale'] === 0)
-					return report['Meter Value (Parsed)'];
+				if (report.hasOwnProperty('Properties2') &&
+					report.Properties2.hasOwnProperty('Scale bits 10') &&
+					report.Properties2['Scale bits 10'] !== 2)
+					return null;
 				
-				return null;
+				return report['Meter Value (Parsed)'];
 			}
 		}
 	},

--- a/drivers/FGS-223/driver.js
+++ b/drivers/FGS-223/driver.js
@@ -33,12 +33,12 @@ module.exports = new ZwaveDriver( path.basename(__dirname), {
 			},
 			'command_report': 'METER_REPORT',
 			'command_report_parser': report => {
-				if (report.hasOwnProperty('Properties1') &&
-				report.Properties1.hasOwnProperty('Scale') &&
-				report.Properties1['Scale'] === 2)
-					return report['Meter Value (Parsed)'];
-					
-				return null;
+				if (report.hasOwnProperty('Properties2') &&
+					report.Properties2.hasOwnProperty('Scale bits 10') &&
+					report.Properties2['Scale bits 10'] !== 0)
+					return null;
+				
+				return report['Meter Value (Parsed)'];
 			}
 		},
 		
@@ -54,12 +54,12 @@ module.exports = new ZwaveDriver( path.basename(__dirname), {
 			},
 			'command_report': 'METER_REPORT',
 			'command_report_parser': report => {
-				if (report.hasOwnProperty('Properties1') &&
-				report.Properties1.hasOwnProperty('Scale') &&
-				report.Properties1['Scale'] === 0)
-					return report['Meter Value (Parsed)'];
+				if (report.hasOwnProperty('Properties2') &&
+					report.Properties2.hasOwnProperty('Scale bits 10') &&
+					report.Properties2['Scale bits 10'] !== 0)
+					return null;
 				
-				return null;
+				return report['Meter Value (Parsed)'];
 			}
 		}
 	},


### PR DESCRIPTION
Reverts athombv/com.fibaro#66

Doesn't work for FGS-2x3. It doesn't send Properties1.Scale back, it has to be matched on scale bits, which is 0 for measure power and 2 for meter power.