### PR TITLE
FGD-212 - Parameters Update

### DIFF
--- a/app.json
+++ b/app.json
@@ -1823,13 +1823,14 @@
 					}
 				},
 				"associationGroups": [
-					1,
-					2,
-					3,
-					4,
-					5
+					1
 				],
 				"defaultConfiguration": [
+					{
+						"id": 23,
+						"size": 1,
+						"value": 0
+					},
 					{
 						"id": 28,
 						"size": 1,
@@ -2100,7 +2101,7 @@
 						"en": "Double click",
 						"nl": "Dubbel klik"
 					},
-					"value": true,
+					"value": false,
 					"hint": {
 						"en": "Set the brightness level to max on double click (disable or enable)",
 						"nl": "Stel helderheid in op maximaal bij dubbel klikken"
@@ -2179,6 +2180,71 @@
 					"hint": {
 						"en": "Functionality of S1 becomes the functionality of S2, and vice versa.",
 						"nl": "Omwisselen van functionaliteit tussen schakelaar 1 en schakelaar 2."
+					}
+				},
+				{
+					"id": "watt_report",
+					"type": "number",
+					"label": {
+						"en": "Wattage Report Threshold",
+						"nl": "Wattage Verzending Drempel"
+					},
+					"value": 10,
+					"attr": {
+						"min": 0,
+						"max": 100
+					},
+					"hint": {
+						"en": "Determine how much the wattage must change (percentage), before value is being send immediatly",
+						"nl": "Bepaal hoeveel wattage er moet veranderen (percentage), voor de waarde meteen word verstuurd"
+					}
+				},
+				{
+					"id": "watt_interval",
+					"type": "number",
+					"label": {
+						"en": "Wattage Report Interval",
+						"nl": "Wattage Verzending Interval"
+					},
+					"value": 3600,
+					"attr": {
+						"min": 0,
+						"max": 32767
+					},
+					"hint": {
+						"en": "Determine on which interval (in seconds) the value is being send, the timer is reset on every report. Range: 0 (Off), 1 - 32767",
+						"nl": "Bepaal op welk interval (in seconden) de waarde word verzonden, de timer word bij elke verzending gereset. Bereik: 0 (Uit), 1 - 32767"
+					}
+				},
+				{
+					"id": "kwh_report",
+					"type": "number",
+					"label": {
+						"en": "Timer functionality (auto - off) in seconds",
+						"nl": "Automatisch uitschakelen na (seconden)"
+					},
+					"value": 0.1,
+					"attr": {
+						"min": 0,
+						"max": 2.55,
+						"step": 0.01
+					},
+					"hint": {
+						"en": "Determine how much the kWh must change before it is being send. Range: 0 (Off), 0.01 - 2.55 kWh",
+						"nl": "Bepaal hoeveel de kWh moet veranderen voor het verzonden word. Bereik: 0 (Uit), 0,01 - 2,55 kWh"
+					}
+				},
+				{
+					"id": "self_measurement",
+					"type": "checkbox",
+					"label": {
+						"en": "Include Own Usage",
+						"nl": "Inclusief Eigen Verbruik"
+					},
+					"value": false,
+					"hint": {
+						"en": "Determine if the usage of the Dimmer 2 itself is added to the kWh total.",
+						"nl": "Bepaal of het verbruik van de Dimmer 2 zelf word toegevoegd aan het kWh totaal."
 					}
 				}
 			]

--- a/app.json
+++ b/app.json
@@ -2220,8 +2220,8 @@
 					"id": "kwh_report",
 					"type": "number",
 					"label": {
-						"en": "Timer functionality (auto - off) in seconds",
-						"nl": "Automatisch uitschakelen na (seconden)"
+						"en": "kWh Report Threshold",
+						"nl": "kWh Verzending Drempel"
 					},
 					"value": 0.1,
 					"attr": {

--- a/drivers/FGD-212/driver.js
+++ b/drivers/FGD-212/driver.js
@@ -139,6 +139,23 @@ module.exports = new ZwaveDriver(path.basename(__dirname), {
 			"index": 34,
 			"size": 1,
 		},
+		"watt_report": {
+			"index": 50,
+			"size": 1,
+		},
+		"watt_interval": {
+			"index": 52,
+			"size": 2,
+		},
+		"kwh_report": {
+			"index": 53,
+			"size": 2,
+			"parser": value => new Buffer([value * 100])
+		},
+		"self_measurement": {
+			"index": 54,
+			"size": 1,
+		},
 	}
 });
 


### PR DESCRIPTION
I removed association groups again that are not really needed for the
dimmer 2.
1. can cause strange behavior as of a report from a user.
https://forum.athom.com/discussion/comment/40477/#Comment_40477
  - group 2 and 4 use BASIC_SET commands, not handled by the driver
  - group 5 uses Multi_Level commands on S2 dimming, can update driver itself and thus sending out "dimming level changed" trigger,
and a possible re-trigger because of the "output state" being asked, by homey
2. causes more traffic for homey to handle, less traffic is better.

added parameters:
50 - Wattage Report Threshold
52 - Wattage Report Interval
53 - kWh Report Threshold
54 - Include Own Usage

changed defaultConfig parameter:
23 - Double click = 100% => false
since scene activation is on by default, it can cause user confusion that lights turn on 100% when double clicking,
instead of just sending Scene Actication "Double Press Left"