### PR TITLE
Add switch behaviour setting for FGS222

### DIFF
--- a/config/drivers/FGS-222.json
+++ b/config/drivers/FGS-222.json
@@ -100,7 +100,7 @@
 			},
 			"hint": {
 				"en": "What type of switch is connected. (default = Momentary Switch)",
-				"nl": "Wat van soort schakelaar is aangesloten. (standaard = Puls Schakelaar"
+				"nl": "Wat van soort schakelaar is aangesloten. (standaard = Puls Schakelaar)"
 			},
 			"value": "1",
 			"values": [
@@ -116,6 +116,35 @@
 					"label": {
 						"en": "Toggle Switch",
 						"nl": "Tuimel Schakelaar"
+					}
+				}
+			]
+		},
+		{
+			"id": "switch_behaviour",
+			"type": "dropdown",
+			"label": {
+				"en": "Switch Behaviour",
+				"nl": "Schakelaar Gedrag"
+			},
+			"hint": {
+				"en": "How the relays behave when the switch is toggled. (default = Toggle when switched)",
+				"nl": "Gedrag van de relays als de schakelaar omgezet word. (standaard = Wissel als de schakelaar omgehaald word)"
+			},
+			"value": "0",
+			"values": [
+				{
+					"id": "0",
+					"label": {
+						"en": "Toggle when switched",
+						"nl": "Wissel als de schakelaar omgehaald word"
+					}
+				},
+				{
+					"id": "1",
+					"label": {
+						"en": "On when switch is turned On",
+						"nl": "Aan als de schakelaar op Aan staat"
 					}
 				}
 			]

--- a/drivers/FGS-222/driver.js
+++ b/drivers/FGS-222/driver.js
@@ -38,6 +38,10 @@ module.exports = new ZwaveDriver( path.basename(__dirname), {
 			"index": 14,
 			"size": 1,
 		},
+		"switch_behaviour": {
+			"index": 13,
+			"size": 1,
+		},
 		"save_power_state": {
 			"index": 16,
 			"size": 1,


### PR DESCRIPTION
Needed when using a relay to switch a ventilation unit to keep the
3-setting switch functioning properly.