### PR TITLE
Add setOnDim and 'Force brightness' action card for FGD-21x dimmers

### DIFF
--- a/config/drivers/FGD-211.json
+++ b/config/drivers/FGD-211.json
@@ -41,6 +41,11 @@
 			}
 		]
 	},
+	"capabilitiesOptions": {
+		"onoff": {
+			"setOnDim": false
+		}
+	},
 	"class": "light",
 	"capabilities": [
 		"dim",

--- a/config/drivers/FGD-212.json
+++ b/config/drivers/FGD-212.json
@@ -33,6 +33,11 @@
 			}
 		]
 	},
+	"capabilitiesOptions": {
+		"onoff": {
+			"setOnDim": false
+		}
+	},
 	"mobile": {
 		"components": [
 			{

--- a/config/flow/actions/FGD-212.json
+++ b/config/flow/actions/FGD-212.json
@@ -1,0 +1,24 @@
+[
+	{
+		"id": "FGD-212_set_brightness",
+		"title": {
+			"en": "Set 'Forced Brightness'",
+			"nl": "Stel 'Geforceerde helderheid' in"
+		},
+		"args": [
+			{
+				"name": "device",
+				"type": "device",
+				"filter": "driver_id=FGD-212"
+			},
+			{
+				"name": "set_forcedbrightnesslevel",
+				"type": "range",
+				"min": 0,
+				"max": 100,
+				"step": 1,
+				"label": "%"
+			}
+		]
+	}
+]

--- a/drivers/FGD-212/driver.js
+++ b/drivers/FGD-212/driver.js
@@ -223,3 +223,36 @@ Homey.manager('flow').on('trigger.FGD-212_roller', (callback, args, state) => {
 
 	return callback(null, false);
 });
+
+Homey.manager('flow').on('action.FGD-212_set_brightness', (callback, args) => {
+	const node = module.exports.nodes[args.device['token']];
+	if (args.hasOwnProperty("set_forcedbrightnesslevel") && node.instance.CommandClass['COMMAND_CLASS_CONFIGURATION']) {
+		//Send parameter values to module
+		node.instance.CommandClass['COMMAND_CLASS_CONFIGURATION'].CONFIGURATION_SET({
+			"Parameter Number": 19,
+			"Level": {
+				"Size": 1,
+				"Default": false
+			},
+			'Configuration Value': new Buffer([args.set_forcedbrightnesslevel])
+		}, (err, result) => {
+			// If error, stop flow card
+			if (err) {
+				Homey.error(err);
+				return callback(null, false);
+			}
+
+			// If properly transmitted, change the setting and finish flow card
+			if (result === "TRANSMIT_COMPLETE_OK") {
+				//Set the device setting to this flow value
+				module.exports.setSettings(node.device_data, {
+					"forced_brightness_level": args.set_forcedbrightnesslevel,
+				});
+				return callback(null, true);
+			}
+			// no transmition, stop flow card
+			return callback(null, false);
+		});
+	}
+	return callback(null, false);
+});


### PR DESCRIPTION
Changes implemented and tested before making the PR

**1. Add setOnDim to FGD-21x dimmers**
Changes: 
Updated app.json for the FGD-21x dimmers to incorporate the setOnDim capabilitiesOption as released in Homey v1.1.9. 

Test results:
Tested and working ok on FGD-212

Additional notes: 
@caseda already added it to the rgbw rewrite; not included in this PR

**2. Add "Set 'Force brightness'" action card for FGD-212 dimmer**
Changes: 
Added action card (app.json) and listener (driver.js) for the FGD-212 dimmer to set the "force brightness" level from a flow. 

Rationale:
Advantage is that forced brightness level can be set time / state based... e.g. light on the hallway will only be turned on to 20% during the night and 100% during day time

Test results:
Have been testing this code for several weeks at home on multiple dimmers; works ok on FGD-212