### PR TITLE
[app 1.2.1] resolve error after successful transmission via FGD-212_set_brightness action card

### DIFF
--- a/drivers/FGD-212/driver.js
+++ b/drivers/FGD-212/driver.js
@@ -254,5 +254,5 @@ Homey.manager('flow').on('action.FGD-212_set_brightness', (callback, args) => {
 		});
 	}
 
-	return callback('unknown_error');
+	else return callback('unknown_error');
 });


### PR DESCRIPTION
Minor error in line 257: `return callback('unknown_error');` results in 'unknown_error' even after successful transmission; parameter is update in devices and Homey.

Change code to: `else return callback('unknown_error');`

tested ok