### PR TITLE
Dimmer state, power reset & set timer card

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,13 @@ When the app has just started, it can take up to 2 minutes before it reacts.
 If it takes longer you (probably) need to restart your homey.
 
 ## Change Log:
+### v 1.3.2
+**fixed:**  
+FGD-211, FGD-212: dimmer on/off state not updated   
+**update:**
+FGD-212, FGRGBWM-441, FGRM-222, FGS-2x3, FGWPE-101, FGWPx-102-PLUS: add power meter reset flow card   
+FGD-212: add set timer flow card    
+
 ### v 1.3.1
 FGGC-001: add additional functionality for Swipe
 

--- a/app.json
+++ b/app.json
@@ -3,7 +3,7 @@
   "name": {
     "en": "Fibaro"
   },
-  "version": "1.3.1",
+  "version": "1.3.2",
   "compatibility": ">=1.1.9",
   "description": {
     "en": "Fibaro devices for Homey"
@@ -1755,6 +1755,48 @@
         ]
       },
       {
+        "id": "FGD-212_set_timer",
+        "title": {
+          "en": "Set timer functionality",
+          "nl": "Stel automatisch uitschakelen in"
+        },
+        "hint": {
+          "en": "Set the 'Timer functionality' (auto - off) parameter in seconds.\nRange: 1 - 32767\n0 function disabled\nDefault: 0",
+          "nl": "Stel de 'automatisch uitschakelen' parameter in.\nBereik: 1 - 32767\n0 functie uitgeschakeld\nStandaard: 0"
+        },
+        "args": [
+          {
+            "name": "device",
+            "type": "device",
+            "filter": "driver_id=FGD-212"
+          },
+          {
+            "name": "set_timer_functionality",
+            "type": "number",
+            "min": 0,
+            "max": 32767
+          }
+        ]
+      },
+      {
+        "id": "FGD-212_reset_meter",
+        "title": {
+          "en": "Reset meter values",
+          "nl": "Meter waarden resetten"
+        },
+        "hint": {
+          "en": "Reset the accumulated power usage (kWh). Can not be reversed.",
+          "nl": "Reset de stroomverbruik (kWh) waarden. Kan niet ongedaan gemaakt worden. "
+        },
+        "args": [
+          {
+            "name": "device",
+            "type": "device",
+            "filter": "driver_id=FGD-212"
+          }
+        ]
+      },
+      {
         "id": "RGBW_specific",
         "title": {
           "en": "Set specific brightness",
@@ -1961,6 +2003,78 @@
         ]
       },
       {
+        "id": "FGRGBWM-441_reset_meter",
+        "title": {
+          "en": "Reset meter values",
+          "nl": "Meter waarden resetten"
+        },
+        "hint": {
+          "en": "Reset the accumulated power usage (kWh). Can not be reversed.",
+          "nl": "Reset de stroomverbruik (kWh) waarden. Kan niet ongedaan gemaakt worden. "
+        },
+        "args": [
+          {
+            "name": "device",
+            "type": "device",
+            "filter": "driver_id=FGRGBWM-441"
+          }
+        ]
+      },
+      {
+        "id": "FGRM-222_reset_meter",
+        "title": {
+          "en": "Reset meter values",
+          "nl": "Meter waarden resetten"
+        },
+        "hint": {
+          "en": "Reset the accumulated power usage (kWh). Can not be reversed.",
+          "nl": "Reset de stroomverbruik (kWh) waarden. Kan niet ongedaan gemaakt worden. "
+        },
+        "args": [
+          {
+            "name": "device",
+            "type": "device",
+            "filter": "driver_id=FGRM-222"
+          }
+        ]
+      },
+      {
+        "id": "FGS-213_reset_meter",
+        "title": {
+          "en": "Reset meter values",
+          "nl": "Meter waarden resetten"
+        },
+        "hint": {
+          "en": "Reset the accumulated power usage (kWh). Can not be reversed.",
+          "nl": "Reset de stroomverbruik (kWh) waarden. Kan niet ongedaan gemaakt worden. "
+        },
+        "args": [
+          {
+            "name": "device",
+            "type": "device",
+            "filter": "driver_id=FGS-213"
+          }
+        ]
+      },
+      {
+        "id": "FGS-223_reset_meter",
+        "title": {
+          "en": "Reset meter values",
+          "nl": "Meter waarden resetten"
+        },
+        "hint": {
+          "en": "Reset the accumulated power usage (kWh). Can not be reversed.",
+          "nl": "Reset de stroomverbruik (kWh) waarden. Kan niet ongedaan gemaakt worden. "
+        },
+        "args": [
+          {
+            "name": "device",
+            "type": "device",
+            "filter": "driver_id=FGS-223"
+          }
+        ]
+      },
+      {
         "id": "FGWPE_led_on",
         "title": {
           "en": "LED Colour, On State",
@@ -2134,6 +2248,24 @@
         ]
       },
       {
+        "id": "FGWPE-101_reset_meter",
+        "title": {
+          "en": "Reset meter values",
+          "nl": "Meter waarden resetten"
+        },
+        "hint": {
+          "en": "Reset the accumulated power usage (kWh). Can not be reversed.",
+          "nl": "Reset de stroomverbruik (kWh) waarden. Kan niet ongedaan gemaakt worden. "
+        },
+        "args": [
+          {
+            "name": "device",
+            "type": "device",
+            "filter": "driver_id=FGWPE-101"
+          }
+        ]
+      },
+      {
         "id": "FGWPx-102-PLUS_led_on",
         "title": {
           "en": "LED Colour, On State",
@@ -2303,6 +2435,24 @@
                 }
               }
             ]
+          }
+        ]
+      },
+      {
+        "id": "FGWPx-102-PLUS_reset_meter",
+        "title": {
+          "en": "Reset meter values",
+          "nl": "Meter waarden resetten"
+        },
+        "hint": {
+          "en": "Reset the accumulated power usage (kWh). Can not be reversed.",
+          "nl": "Reset de stroomverbruik (kWh) waarden. Kan niet ongedaan gemaakt worden. "
+        },
+        "args": [
+          {
+            "name": "device",
+            "type": "device",
+            "filter": "driver_id=FGWPx-102-PLUS"
           }
         ]
       }

--- a/config/flow/actions/FGD-212.json
+++ b/config/flow/actions/FGD-212.json
@@ -1,5 +1,4 @@
-[
-	{
+[{
 		"id": "FGD-212_set_brightness",
 		"title": {
 			"en": "Set forced brightness",
@@ -9,8 +8,7 @@
 			"en": "Change the \"set forced brightness\" parameter of your dimmer. If this parameter is active, switching on the Dimmer 2 (S1 single click) will always set this brightness level, 0 will disable this function.\nRange: 1 - 99 percentage of brightness.",
 			"nl": "Stel de \"geforceerde helderheid\" parameter van een dimmer in. Wanneer deze parameter actief is, zal bij het inschakelen van Dimmer 2 (S1 single click) altijd naar deze helderheid inschakelen, 0 schakelt deze functie uit.\nBereik: 1 - 99 helderheids percentage."
 		},
-		"args": [
-			{
+		"args": [{
 				"name": "device",
 				"type": "device",
 				"filter": "driver_id=FGD-212"
@@ -36,8 +34,7 @@
 			"en": "Change the brightness and specify the transition duration, 0 will change brightness instantly.\nRange: 0 - 127 seconds or minutes (depending on selection).",
 			"nl": "Verander de helderheid en specificeer the gewenste transitie tijdsduur, 0 is onmiddellijke verandering van helderheid.\nBereik: 0 - 127 seconden of minuten (afhankelijk van de selectie)."
 		},
-		"args": [
-			{
+		"args": [{
 				"name": "device",
 				"type": "device",
 				"filter": "driver_id=FGD-212"
@@ -64,8 +61,7 @@
 			{
 				"name": "duration_unit",
 				"type": "dropdown",
-				"values": [
-					{
+				"values": [{
 						"id": "0",
 						"label": {
 							"en": "sec",
@@ -82,5 +78,44 @@
 				]
 			}
 		]
+	},
+	{
+		"id": "FGD-212_set_timer",
+		"title": {
+			"en": "Set timer functionality",
+			"nl": "Stel automatisch uitschakelen in"
+		},
+		"hint": {
+			"en": "Set the 'Timer functionality' (auto - off) parameter in seconds.\nRange: 1 - 32767\n0 function disabled\nDefault: 0",
+			"nl": "Stel de 'automatisch uitschakelen' parameter in.\nBereik: 1 - 32767\n0 functie uitgeschakeld\nStandaard: 0"
+		},
+		"args": [{
+				"name": "device",
+				"type": "device",
+				"filter": "driver_id=FGD-212"
+			},
+			{
+				"name": "set_timer_functionality",
+				"type": "number",
+				"min": 0,
+				"max": 32767
+			}
+		]
+	},
+	{
+		"id": "FGD-212_reset_meter",
+		"title": {
+			"en": "Reset meter values",
+			"nl": "Meter waarden resetten"
+		},
+		"hint": {
+			"en": "Reset the accumulated power usage (kWh). Can not be reversed.",
+			"nl": "Reset de stroomverbruik (kWh) waarden. Kan niet ongedaan gemaakt worden. "
+		},
+		"args": [{
+			"name": "device",
+			"type": "device",
+			"filter": "driver_id=FGD-212"
+		}]
 	}
 ]

--- a/config/flow/actions/FGRGBWM-441.json
+++ b/config/flow/actions/FGRGBWM-441.json
@@ -1,12 +1,10 @@
-[
-	{
+[{
 		"id": "RGBW_specific",
 		"title": {
 			"en": "Set specific brightness",
 			"nl": "Stel specifieke helderheid in"
 		},
-		"args": [
-			{
+		"args": [{
 				"name": "device",
 				"type": "device",
 				"filter": "driver_id=FGRGBWM-441"
@@ -14,8 +12,7 @@
 			{
 				"name": "color",
 				"type": "dropdown",
-				"values": [
-					{
+				"values": [{
 						"id": "r",
 						"label": {
 							"en": "Red output",
@@ -62,8 +59,7 @@
 			"en": "Choose random color",
 			"nl": "Kies willekeurige kleur"
 		},
-		"args": [
-			{
+		"args": [{
 				"name": "device",
 				"type": "device",
 				"filter": "driver_id=FGRGBWM-441"
@@ -71,8 +67,7 @@
 			{
 				"name": "range",
 				"type": "dropdown",
-				"values": [
-					{
+				"values": [{
 						"id": "rgb",
 						"label": {
 							"en": "RGB",
@@ -135,8 +130,7 @@
 			"en": "Animations only work if the mode type is set to RGB(W)",
 			"nl": "Animaties werken alleen als de mode type is ingesteld op RGB(W)"
 		},
-		"args": [
-			{
+		"args": [{
 				"name": "device",
 				"type": "device",
 				"filter": "driver_id=FGRGBWM-441"
@@ -144,8 +138,7 @@
 			{
 				"name": "animation",
 				"type": "dropdown",
-				"values": [
-					{
+				"values": [{
 						"id": "6",
 						"label": {
 							"en": "Fire",
@@ -204,5 +197,21 @@
 				]
 			}
 		]
+	},
+	{
+		"id": "FGRGBWM-441_reset_meter",
+		"title": {
+			"en": "Reset meter values",
+			"nl": "Meter waarden resetten"
+		},
+		"hint": {
+			"en": "Reset the accumulated power usage (kWh). Can not be reversed.",
+			"nl": "Reset de stroomverbruik (kWh) waarden. Kan niet ongedaan gemaakt worden. "
+		},
+		"args": [{
+			"name": "device",
+			"type": "device",
+			"filter": "driver_id=FGRGBWM-441"
+		}]
 	}
 ]

--- a/config/flow/actions/FGRM-222.json
+++ b/config/flow/actions/FGRM-222.json
@@ -1,0 +1,16 @@
+[{
+	"id": "FGRM-222_reset_meter",
+	"title": {
+		"en": "Reset meter values",
+		"nl": "Meter waarden resetten"
+	},
+	"hint": {
+		"en": "Reset the accumulated power usage (kWh). Can not be reversed.",
+		"nl": "Reset de stroomverbruik (kWh) waarden. Kan niet ongedaan gemaakt worden. "
+	},
+	"args": [{
+		"name": "device",
+		"type": "device",
+		"filter": "driver_id=FGRM-222"
+	}]
+}]

--- a/config/flow/actions/FGS-213.json
+++ b/config/flow/actions/FGS-213.json
@@ -1,0 +1,16 @@
+[{
+	"id": "FGS-213_reset_meter",
+	"title": {
+		"en": "Reset meter values",
+		"nl": "Meter waarden resetten"
+	},
+	"hint": {
+		"en": "Reset the accumulated power usage (kWh). Can not be reversed.",
+		"nl": "Reset de stroomverbruik (kWh) waarden. Kan niet ongedaan gemaakt worden. "
+	},
+	"args": [{
+		"name": "device",
+		"type": "device",
+		"filter": "driver_id=FGS-213"
+	}]
+}]

--- a/config/flow/actions/FGS-223.json
+++ b/config/flow/actions/FGS-223.json
@@ -1,0 +1,16 @@
+[{
+	"id": "FGS-223_reset_meter",
+	"title": {
+		"en": "Reset meter values",
+		"nl": "Meter waarden resetten"
+	},
+	"hint": {
+		"en": "Reset the accumulated power usage (kWh). Can not be reversed.",
+		"nl": "Reset de stroomverbruik (kWh) waarden. Kan niet ongedaan gemaakt worden. "
+	},
+	"args": [{
+		"name": "device",
+		"type": "device",
+		"filter": "driver_id=FGS-223"
+	}]
+}]

--- a/config/flow/actions/FGWPE-101.json
+++ b/config/flow/actions/FGWPE-101.json
@@ -1,12 +1,10 @@
-[
-	{
+[{
 		"id": "FGWPE_led_on",
 		"title": {
 			"en": "LED Colour, On State",
 			"nl": "LED Kleur, Aan Status"
 		},
-		"args": [
-			{
+		"args": [{
 				"name": "device",
 				"type": "device",
 				"filter": "driver_id=FGWPE-101"
@@ -14,8 +12,7 @@
 			{
 				"name": "color",
 				"type": "dropdown",
-				"values": [
-					{
+				"values": [{
 						"id": "0",
 						"label": {
 							"en": "Power: Predefined Colours",
@@ -95,8 +92,7 @@
 			"en": "LED Colour, Off State",
 			"nl": "LED Kleur, Uit Status"
 		},
-		"args": [
-			{
+		"args": [{
 				"name": "device",
 				"type": "device",
 				"filter": "driver_id=FGWPE-101"
@@ -104,8 +100,7 @@
 			{
 				"name": "color",
 				"type": "dropdown",
-				"values": [
-					{
+				"values": [{
 						"id": "0",
 						"label": {
 							"en": "Last Colour before off",
@@ -171,5 +166,21 @@
 				]
 			}
 		]
+	},
+	{
+		"id": "FGWPE-101_reset_meter",
+		"title": {
+			"en": "Reset meter values",
+			"nl": "Meter waarden resetten"
+		},
+		"hint": {
+			"en": "Reset the accumulated power usage (kWh). Can not be reversed.",
+			"nl": "Reset de stroomverbruik (kWh) waarden. Kan niet ongedaan gemaakt worden. "
+		},
+		"args": [{
+			"name": "device",
+			"type": "device",
+			"filter": "driver_id=FGWPE-101"
+		}]
 	}
 ]

--- a/config/flow/actions/FGWPx-102-PLUS.json
+++ b/config/flow/actions/FGWPx-102-PLUS.json
@@ -1,12 +1,10 @@
-[
-	{
+[{
 		"id": "FGWPx-102-PLUS_led_on",
 		"title": {
 			"en": "LED Colour, On State",
 			"nl": "LED Kleur, Aan Status"
 		},
-		"args": [
-			{
+		"args": [{
 				"name": "device",
 				"type": "device",
 				"filter": "driver_id=FGWPx-102-PLUS"
@@ -14,8 +12,7 @@
 			{
 				"name": "color",
 				"type": "dropdown",
-				"values": [
-					{
+				"values": [{
 						"id": "1",
 						"label": {
 							"en": "Power: Predefined Colours",
@@ -95,8 +92,7 @@
 			"en": "LED Colour, Off State",
 			"nl": "LED Kleur, Uit Status"
 		},
-		"args": [
-			{
+		"args": [{
 				"name": "device",
 				"type": "device",
 				"filter": "driver_id=FGWPx-102-PLUS"
@@ -104,8 +100,7 @@
 			{
 				"name": "color",
 				"type": "dropdown",
-				"values": [
-					{
+				"values": [{
 						"id": "1",
 						"label": {
 							"en": "Last Colour before off",
@@ -171,5 +166,21 @@
 				]
 			}
 		]
+	},
+	{
+		"id": "FGWPx-102-PLUS_reset_meter",
+		"title": {
+			"en": "Reset meter values",
+			"nl": "Meter waarden resetten"
+		},
+		"hint": {
+			"en": "Reset the accumulated power usage (kWh). Can not be reversed.",
+			"nl": "Reset de stroomverbruik (kWh) waarden. Kan niet ongedaan gemaakt worden. "
+		},
+		"args": [{
+			"name": "device",
+			"type": "device",
+			"filter": "driver_id=FGWPx-102-PLUS"
+		}]
 	}
 ]

--- a/drivers/FGD-211/driver.js
+++ b/drivers/FGD-211/driver.js
@@ -34,7 +34,21 @@ module.exports = new ZwaveDriver(path.basename(__dirname), {
 				};
 			},
 			command_report: 'SWITCH_MULTILEVEL_REPORT',
-			command_report_parser: report => report['Value (Raw)'][0] / 100,
+			command_report_parser: (report, node) => {
+				if (typeof report !== 'undefined' && typeof report.Value === 'string') {
+					return (report.Value === 'on/enable') ? 1.0 : 0.0;
+				}
+
+				// Setting on/off state when dimming
+				if (!node.state.onoff || node.state.onoff !== (report['Value (Raw)'][0] > 0)) {
+					node.state.onoff = (report['Value (Raw)'][0] > 0);
+				}
+
+				if (report.hasOwnProperty('Value (Raw)') && typeof report['Value (Raw)'] !== 'undefined') {
+					return report['Value (Raw)'][0] / 100;
+				}
+				return null;
+			},
 		},
 	},
 	settings: {
@@ -134,19 +148,25 @@ module.exports.on('initNode', token => {
 });
 
 Homey.manager('flow').on('trigger.FGD-211_momentary', (callback, args, state) => {
-	if (args && state && state.scene === args.scene) { return callback(null, true); }
+	if (args && state && state.scene === args.scene) {
+		return callback(null, true);
+	}
 
 	return callback(null, false);
 });
 
 Homey.manager('flow').on('trigger.FGD-211_toggle', (callback, args, state) => {
-	if (args && state && state.scene === args.scene) { return callback(null, true); }
+	if (args && state && state.scene === args.scene) {
+		return callback(null, true);
+	}
 
 	return callback(null, false);
 });
 
 Homey.manager('flow').on('trigger.FGD-211_roller', (callback, args, state) => {
-	if (args && state && state.scene === args.scene) { return callback(null, true); }
+	if (args && state && state.scene === args.scene) {
+		return callback(null, true);
+	}
 
 	return callback(null, false);
 });

--- a/drivers/FGD-212/driver.js
+++ b/drivers/FGD-212/driver.js
@@ -36,7 +36,21 @@ module.exports = new ZwaveDriver(path.basename(__dirname), {
 				};
 			},
 			command_report: 'SWITCH_MULTILEVEL_REPORT',
-			command_report_parser: report => report['Value (Raw)'][0] / 100,
+			command_report_parser: (report, node) => {
+				if (typeof report !== 'undefined' && typeof report.Value === 'string') {
+					return (report.Value === 'on/enable') ? 1.0 : 0.0;
+				}
+
+				// Setting on/off state when dimming
+				if (!node.state.onoff || node.state.onoff !== (report['Value (Raw)'][0] > 0)) {
+					node.state.onoff = (report['Value (Raw)'][0] > 0);
+				}
+
+				if (report.hasOwnProperty('Value (Raw)') && typeof report['Value (Raw)'] !== 'undefined') {
+					return report['Value (Raw)'][0] / 100;
+				}
+				return null;
+			},
 		},
 
 		measure_power: {
@@ -230,13 +244,10 @@ Homey.manager('flow').on('trigger.FGD-212_roller', (callback, args, state) => {
 Homey.manager('flow').on('action.FGD-212_set_brightness', (callback, args) => {
 	const node = module.exports.nodes[args.device.token];
 
-	// Validate input to be within specified range (0 - 0.99)
-	if (node
-		&& args.hasOwnProperty('set_forced_brightness_level')
-		&& typeof args.set_forced_brightness_level === 'number'
-		&& args.set_forced_brightness_level > 1) {
-		return callback('forced_brightness_level_out_of_range');
-	}
+	// Check forced brightness level property
+	if (!args.hasOwnProperty('set_forced_brightness_level')) return callback('set_forced_brightness_level_property_missing');
+	if (typeof args.set_forced_brightness_level !== 'number') return callback('forced_brightness_level_is_not_a_number');
+	if (args.set_forced_brightness_level > 1) return callback('forced_brightness_level_out_of_range');
 
 	if (node && args.hasOwnProperty('set_forced_brightness_level') && typeof args.set_forced_brightness_level === 'number') {
 
@@ -269,16 +280,10 @@ Homey.manager('flow').on('action.FGD-212_set_brightness', (callback, args) => {
 Homey.manager('flow').on('action.FGD-212_dim_duration', (callback, args) => {
 	const node = module.exports.nodes[args.device.token];
 
-	// Check forced brightness level property
-	if (!args.hasOwnProperty('set_forced_brightness_level')) return callback('set_forced_brightness_level_property_missing');
-	if (typeof args.set_forced_brightness_level !== 'number') return callback('forced_brightness_level_is_not_a_number');
-	if (args.set_forced_brightness_level > 1) return callback('forced_brightness_level_out_of_range');
-
 	// Check dimming duration level property
 	if (!args.hasOwnProperty('dimming_duration')) return callback('dimming_duration_property_missing');
 	if (typeof args.dimming_duration !== 'number') return callback('dimming_duration_is_not_a_number');
-	if (args.dimming_duration > 127) return callback('dimming_duration_out_of_range');
-
+	if (args.brightness_level > 1 || args.dimming_duration > 127) return callback('dimming_duration_out_of_range');
 
 	if (node && node.instance.CommandClass.COMMAND_CLASS_SWITCH_MULTILEVEL) {
 		node.instance.CommandClass.COMMAND_CLASS_SWITCH_MULTILEVEL.SWITCH_MULTILEVEL_SET({
@@ -288,6 +293,64 @@ Homey.manager('flow').on('action.FGD-212_dim_duration', (callback, args) => {
 			if (err) return callback(err);
 
 			if (result === 'TRANSMIT_COMPLETE_OK') {
+				return callback(null, true);
+			}
+
+			return callback('unknown_response');
+		});
+	} else return callback('unknown_error');
+});
+
+Homey.manager('flow').on('action.FGD-212_set_timer', (callback, args) => {
+	const node = module.exports.nodes[args.device.token];
+
+	// Check dimming duration level property
+	if (!args.hasOwnProperty('set_timer_functionality')) return callback('set_timer_property_missing');
+	if (typeof args.set_timer_functionality !== 'number') return callback('set_timer_is_not_a_number');
+	if (args.set_timer_functionality > 32767) return callback('set_timer_out_of_range');
+
+	const configValue = new Buffer(2);
+	configValue.writeIntBE(args.set_timer_functionality, 0, 2);
+
+	if (node && args.hasOwnProperty('set_timer_functionality') &&
+		node.instance.CommandClass.COMMAND_CLASS_CONFIGURATION) {
+		node.instance.CommandClass.COMMAND_CLASS_CONFIGURATION.CONFIGURATION_SET({
+			'Parameter Number': 10,
+			Level: {
+				Size: 2,
+				Default: false,
+			},
+			'Configuration Value': configValue,
+		}, (err, result) => {
+			if (err) return callback(err);
+
+			// If properly transmitted, change the setting and finish flow card
+			if (result === 'TRANSMIT_COMPLETE_OK') {
+
+				// Set the device setting to this flow value
+				module.exports.setSettings(node.device_data, {
+					timer_functionality: (args.set_timer_functionality),
+				});
+
+				return callback(null, true);
+			}
+
+			return callback('unknown_response');
+		});
+	} else return callback('unknown_error');
+});
+
+Homey.manager('flow').on('action.FGD-212_reset_meter', (callback, args) => {
+	const node = module.exports.nodes[args.device.token];
+
+	if (node &&
+		node.instance.CommandClass.COMMAND_CLASS_METER) {
+		node.instance.CommandClass.COMMAND_CLASS_METER.METER_RESET({}, (err, result) => {
+			if (err) return callback(err);
+
+			// If properly transmitted, change the setting and finish flow card
+			if (result === 'TRANSMIT_COMPLETE_OK') {
+
 				return callback(null, true);
 			}
 

--- a/drivers/FGMS-001-PLUS/driver.js
+++ b/drivers/FGMS-001-PLUS/driver.js
@@ -6,7 +6,6 @@ const ZwaveDriver = require('homey-zwavedriver');
 // http://manuals.fibaro.com/content/manuals/en/FGMS-001/FGMS-001-EN-T-v2.0.pdf
 
 module.exports = new ZwaveDriver(path.basename(__dirname), {
-	debug: true,
 	capabilities: {
 		alarm_motion: {
 			command_class: 'COMMAND_CLASS_NOTIFICATION',
@@ -29,7 +28,7 @@ module.exports = new ZwaveDriver(path.basename(__dirname), {
 					if (report['Event (Parsed)'] === 'Event inactive' &&
 						report.hasOwnProperty('Event Parameter') &&
 						(report['Event Parameter'][0] === 7 ||
-						report['Event Parameter'][0] === 8)) {
+							report['Event Parameter'][0] === 8)) {
 						return false;
 					}
 

--- a/drivers/FGRGBWM-441/driver.js
+++ b/drivers/FGRGBWM-441/driver.js
@@ -169,18 +169,30 @@ module.exports = new ZwaveDriver(path.basename(__dirname), {
 			command_report_parser: report => {
 				if (report && report.hasOwnProperty('Properties2') &&
 					report.Properties2.hasOwnProperty('Scale') &&
-					report.Properties2.Scale !== 0) { return null; }
+					report.Properties2.Scale !== 0) {
+					return null;
+				}
 
 				return report['Meter Value (Parsed)'];
 			},
 		},
 
 		// Minimum required for light mode and inputs
-		light_mode: { command_class: 'COMMAND_CLASS_BASIC' },
-		'measure_voltage.input1': { command_class: 'COMMAND_CLASS_SWITCH_MULTILEVEL' },
-		'measure_voltage.input2': { command_class: 'COMMAND_CLASS_SWITCH_MULTILEVEL' },
-		'measure_voltage.input3': { command_class: 'COMMAND_CLASS_SWITCH_MULTILEVEL' },
-		'measure_voltage.input4': { command_class: 'COMMAND_CLASS_SWITCH_MULTILEVEL' },
+		light_mode: {
+			command_class: 'COMMAND_CLASS_BASIC'
+		},
+		'measure_voltage.input1': {
+			command_class: 'COMMAND_CLASS_SWITCH_MULTILEVEL'
+		},
+		'measure_voltage.input2': {
+			command_class: 'COMMAND_CLASS_SWITCH_MULTILEVEL'
+		},
+		'measure_voltage.input3': {
+			command_class: 'COMMAND_CLASS_SWITCH_MULTILEVEL'
+		},
+		'measure_voltage.input4': {
+			command_class: 'COMMAND_CLASS_SWITCH_MULTILEVEL'
+		},
 	},
 
 	beforeInit: (token, callback) => {
@@ -200,7 +212,12 @@ module.exports = new ZwaveDriver(path.basename(__dirname), {
 				deviceOptions[token].calibrateWhite = parseInt(settings.calibrate_white) / 100 || 0;
 				deviceOptions[token].colorPallet = settings.color_pallet || 'accurate';
 				deviceOptions[token].hueCache = 0;
-				deviceOptions[token].colorCache = { r: 0, g: 0, b: 0, w: 0 };
+				deviceOptions[token].colorCache = {
+					r: 0,
+					g: 0,
+					b: 0,
+					w: 0
+				};
 				deviceOptions[token].realInputConfig1 = parseInt(settings.input_config_1) || 1;
 				deviceOptions[token].realInputConfig2 = parseInt(settings.input_config_2) || 1;
 				deviceOptions[token].realInputConfig3 = parseInt(settings.input_config_3) || 1;
@@ -255,7 +272,9 @@ module.exports = new ZwaveDriver(path.basename(__dirname), {
 		strip_type: (newValue, oldValue, deviceData) => {
 			const node = module.exports.nodes[deviceData.token];
 
-			if (deviceOptions[deviceData.token].stripType !== newValue) { deviceOptions[deviceData.token].stripType = newValue; }
+			if (deviceOptions[deviceData.token].stripType !== newValue) {
+				deviceOptions[deviceData.token].stripType = newValue;
+			}
 
 			// Update light_mode value
 			if (newValue === 'cct' && node.state.light_mode !== 'temperature') {
@@ -324,9 +343,9 @@ module.exports = new ZwaveDriver(path.basename(__dirname), {
 					// Create parameter value
 					const configValue = new Buffer([
 						(deviceOptions[deviceData.token].realInputConfig1 * 16 +
-						deviceOptions[deviceData.token].realInputConfig2),
+							deviceOptions[deviceData.token].realInputConfig2),
 						(deviceOptions[deviceData.token].realInputConfig3 * 16 +
-						deviceOptions[deviceData.token].realInputConfig4),
+							deviceOptions[deviceData.token].realInputConfig4),
 					]);
 
 					// Send values
@@ -357,16 +376,24 @@ module.exports = new ZwaveDriver(path.basename(__dirname), {
 			});
 		},
 		rgbw_white_temperature: (newValue, oldValue, deviceData) => {
-			if (deviceOptions[deviceData.token].rgbWhiteTemp !== newValue) { deviceOptions[deviceData.token].rgbWhiteTemp = newValue; }
+			if (deviceOptions[deviceData.token].rgbWhiteTemp !== newValue) {
+				deviceOptions[deviceData.token].rgbWhiteTemp = newValue;
+			}
 		},
 		white_temperature: (newValue, oldValue, deviceData) => {
-			if (deviceOptions[deviceData.token].whiteTemp !== newValue) { deviceOptions[deviceData.token].whiteTemp = newValue; }
+			if (deviceOptions[deviceData.token].whiteTemp !== newValue) {
+				deviceOptions[deviceData.token].whiteTemp = newValue;
+			}
 		},
 		calibrate_white: (newValue, oldValue, deviceData) => {
-			if (deviceOptions[deviceData.token].calibrateWhite !== newValue / 100) { deviceOptions[deviceData.token].calibrateWhite = newValue / 100; }
+			if (deviceOptions[deviceData.token].calibrateWhite !== newValue / 100) {
+				deviceOptions[deviceData.token].calibrateWhite = newValue / 100;
+			}
 		},
 		white_saturation: (newValue, oldValue, deviceData) => {
-			if (deviceOptions[deviceData.token].whiteSaturation !== newValue / 100) { deviceOptions[deviceData.token].whiteSaturation = newValue / 100; }
+			if (deviceOptions[deviceData.token].whiteSaturation !== newValue / 100) {
+				deviceOptions[deviceData.token].whiteSaturation = newValue / 100;
+			}
 		},
 		transition_mode: {
 			index: 8,
@@ -419,7 +446,9 @@ module.exports = new ZwaveDriver(path.basename(__dirname), {
 				deviceOptions[deviceData.token].realInputConfig1 = parseInt(newValue) || 1;
 
 				// If strip type is not rgb(w) or cct, add 8
-				if (newSettings.strip_type.indexOf('rgb') < 0 && newSettings.strip_type !== 'cct' && parseInt(newValue) < 8) { if (deviceOptions[deviceData.token].realInputConfig1 < 8) deviceOptions[deviceData.token].realInputConfig1 += 8; }
+				if (newSettings.strip_type.indexOf('rgb') < 0 && newSettings.strip_type !== 'cct' && parseInt(newValue) < 8) {
+					if (deviceOptions[deviceData.token].realInputConfig1 < 8) deviceOptions[deviceData.token].realInputConfig1 += 8;
+				}
 
 				deviceOptions[deviceData.token].realInputConfig1 = parseInt(newSettings.input_config_1);
 				deviceOptions[deviceData.token].realInputConfig2 = parseInt(newSettings.input_config_2);
@@ -437,8 +466,7 @@ module.exports = new ZwaveDriver(path.basename(__dirname), {
 					(deviceOptions[deviceData.token].realInputConfig1 * 4096) +
 					(deviceOptions[deviceData.token].realInputConfig2 * 256) +
 					(deviceOptions[deviceData.token].realInputConfig3 * 16) +
-					deviceOptions[deviceData.token].realInputConfig4
-					, 0, 2);
+					deviceOptions[deviceData.token].realInputConfig4, 0, 2);
 
 				return value;
 			},
@@ -450,7 +478,9 @@ module.exports = new ZwaveDriver(path.basename(__dirname), {
 				deviceOptions[deviceData.token].realInputConfig2 = parseInt(newValue) || 1;
 
 				// If strip type is not rgb(w) or cct, add 8
-				if (newSettings.strip_type.indexOf('rgb') < 0 && newSettings.strip_type !== 'cct' && parseInt(newValue) < 8) { if (deviceOptions[deviceData.token].realInputConfig2 < 8) deviceOptions[deviceData.token].realInputConfig2 += 8; }
+				if (newSettings.strip_type.indexOf('rgb') < 0 && newSettings.strip_type !== 'cct' && parseInt(newValue) < 8) {
+					if (deviceOptions[deviceData.token].realInputConfig2 < 8) deviceOptions[deviceData.token].realInputConfig2 += 8;
+				}
 
 				deviceOptions[deviceData.token].realInputConfig1 = parseInt(newSettings.input_config_1);
 				deviceOptions[deviceData.token].realInputConfig2 = parseInt(newSettings.input_config_2);
@@ -468,8 +498,7 @@ module.exports = new ZwaveDriver(path.basename(__dirname), {
 					(deviceOptions[deviceData.token].realInputConfig1 * 4096) +
 					(deviceOptions[deviceData.token].realInputConfig2 * 256) +
 					(deviceOptions[deviceData.token].realInputConfig3 * 16) +
-					deviceOptions[deviceData.token].realInputConfig4
-					, 0, 2);
+					deviceOptions[deviceData.token].realInputConfig4, 0, 2);
 
 				return value;
 			},
@@ -481,7 +510,9 @@ module.exports = new ZwaveDriver(path.basename(__dirname), {
 				deviceOptions[deviceData.token].realInputConfig3 = parseInt(newValue) || 1;
 
 				// If strip type is not rgb(w) or cct, add 8
-				if (newSettings.strip_type.indexOf('rgb') < 0 && newSettings.strip_type !== 'cct' && parseInt(newValue) < 8) { if (deviceOptions[deviceData.token].realInputConfig3 < 8) deviceOptions[deviceData.token].realInputConfig3 += 8; }
+				if (newSettings.strip_type.indexOf('rgb') < 0 && newSettings.strip_type !== 'cct' && parseInt(newValue) < 8) {
+					if (deviceOptions[deviceData.token].realInputConfig3 < 8) deviceOptions[deviceData.token].realInputConfig3 += 8;
+				}
 
 				deviceOptions[deviceData.token].realInputConfig1 = parseInt(newSettings.input_config_1);
 				deviceOptions[deviceData.token].realInputConfig2 = parseInt(newSettings.input_config_2);
@@ -499,8 +530,7 @@ module.exports = new ZwaveDriver(path.basename(__dirname), {
 					(deviceOptions[deviceData.token].realInputConfig1 * 4096) +
 					(deviceOptions[deviceData.token].realInputConfig2 * 256) +
 					(deviceOptions[deviceData.token].realInputConfig3 * 16) +
-					deviceOptions[deviceData.token].realInputConfig4
-					, 0, 2);
+					deviceOptions[deviceData.token].realInputConfig4, 0, 2);
 
 				return value;
 			},
@@ -512,7 +542,9 @@ module.exports = new ZwaveDriver(path.basename(__dirname), {
 				deviceOptions[deviceData.token].realInputConfig4 = parseInt(newValue) || 1;
 
 				// If strip type is not rgb(w) or cct, add 8
-				if (newSettings.strip_type.indexOf('rgb') < 0 && newSettings.strip_type !== 'cct' && parseInt(newValue) < 8) { if (deviceOptions[deviceData.token].realInputConfig4 < 8) deviceOptions[deviceData.token].realInputConfig4 += 8; }
+				if (newSettings.strip_type.indexOf('rgb') < 0 && newSettings.strip_type !== 'cct' && parseInt(newValue) < 8) {
+					if (deviceOptions[deviceData.token].realInputConfig4 < 8) deviceOptions[deviceData.token].realInputConfig4 += 8;
+				}
 
 				deviceOptions[deviceData.token].realInputConfig1 = parseInt(newSettings.input_config_1);
 				deviceOptions[deviceData.token].realInputConfig2 = parseInt(newSettings.input_config_2);
@@ -530,8 +562,7 @@ module.exports = new ZwaveDriver(path.basename(__dirname), {
 					(deviceOptions[deviceData.token].realInputConfig1 * 4096) +
 					(deviceOptions[deviceData.token].realInputConfig2 * 256) +
 					(deviceOptions[deviceData.token].realInputConfig3 * 16) +
-					deviceOptions[deviceData.token].realInputConfig4
-					, 0, 2);
+					deviceOptions[deviceData.token].realInputConfig4, 0, 2);
 
 				return value;
 			},
@@ -557,7 +588,9 @@ module.exports = new ZwaveDriver(path.basename(__dirname), {
 			parser: newValue => new Buffer([newValue * 100]),
 		},
 		color_pallet: (newValue, oldValue, deviceData) => {
-			if (deviceOptions[deviceData.token].colorPallet !== newValue) { deviceOptions[deviceData.token].colorPallet = newValue; }
+			if (deviceOptions[deviceData.token].colorPallet !== newValue) {
+				deviceOptions[deviceData.token].colorPallet = newValue;
+			}
 		},
 	},
 });
@@ -620,7 +653,9 @@ function colorSetParser(color, value, type, node) {
 		module.exports.realtime(node.device_data, 'light_mode', 'color');
 	}
 
-	return { Value: Math.round((rgb[color] / 255) * 99) };
+	return {
+		Value: Math.round((rgb[color] / 255) * 99)
+	};
 }
 
 function temperatureSetParser(color, value, node) {
@@ -647,10 +682,14 @@ function temperatureSetParser(color, value, node) {
 		}
 
 		if (color === deviceOptions[node.device_data.token].stripType.slice(2)) {
-			return { Value: Math.round((node.state.dim || 1) * (1 - value) * 99) };
+			return {
+				Value: Math.round((node.state.dim || 1) * (1 - value) * 99)
+			};
 		}
 
-		return { Value: 'off/disable' };
+		return {
+			Value: 'off/disable'
+		};
 	}
 
 	// If there is a correlated color temperature strip attached
@@ -660,11 +699,17 @@ function temperatureSetParser(color, value, node) {
 			module.exports.realtime(node.device_data, 'light_mode', 'temperature');
 		}
 
-		if (color === 'r' || color === 'g') return { Value: 'off/disable' };
+		if (color === 'r' || color === 'g') return {
+			Value: 'off/disable'
+		};
 
-		if (color === 'b') return { Value: Math.round((node.state.dim || 1) * (1 - value) * 99) };
+		if (color === 'b') return {
+			Value: Math.round((node.state.dim || 1) * (1 - value) * 99)
+		};
 
-		if (color === 'w') return { Value: Math.round((node.state.dim || 1) * value * 99) };
+		if (color === 'w') return {
+			Value: Math.round((node.state.dim || 1) * value * 99)
+		};
 	}
 
 	// If there is a RGB(W) strip attached
@@ -703,21 +748,33 @@ function temperatureSetParser(color, value, node) {
 
 		if (color === 'r') {
 			const rgb = temperatureParser(value, (node.state.dim || 1));
-			return { Value: rgb.r };
+			return {
+				Value: rgb.r
+			};
 		}
 		if (color === 'g') {
 			const rgb = temperatureParser(value, (node.state.dim || 1));
-			return { Value: rgb.g };
+			return {
+				Value: rgb.g
+			};
 		}
 		if (color === 'b') {
 			const rgb = temperatureParser(value, (node.state.dim || 1));
-			return { Value: rgb.b };
+			return {
+				Value: rgb.b
+			};
 		}
 		if (color === 'w' &&
 			deviceOptions[node.device_data.token].rgbWhiteTemp === true &&
-			deviceOptions[node.device_data.token].stripType.indexOf('w') >= 0) { return { Value: Math.min(Math.round((node.state.dim || 1) * (99 * whiteValue)), 99) }; }
+			deviceOptions[node.device_data.token].stripType.indexOf('w') >= 0) {
+			return {
+				Value: Math.min(Math.round((node.state.dim || 1) * (99 * whiteValue)), 99)
+			};
+		}
 
-		return { Value: 'off/disable' };
+		return {
+			Value: 'off/disable'
+		};
 	}
 }
 
@@ -727,7 +784,9 @@ module.exports.on('initNode', token => {
 
 	if (node) {
 		// Setting Temperature to a default value in the middle
-		if (deviceOptions.hasOwnProperty(node.device_data.token) && deviceOptions[node.device_data.token].stripType !== 'cct') { if (!node.state.light_temperature) node.state.light_temperature = 0.5; }
+		if (deviceOptions.hasOwnProperty(node.device_data.token) && deviceOptions[node.device_data.token].stripType !== 'cct') {
+			if (!node.state.light_temperature) node.state.light_temperature = 0.5;
+		}
 
 		// RED
 		if (typeof node.instance.MultiChannelNodes['2'].CommandClass.COMMAND_CLASS_SWITCH_MULTILEVEL !== 'undefined') {
@@ -738,9 +797,17 @@ module.exports.on('initNode', token => {
 				if (command.name && command.name === 'SWITCH_MULTILEVEL_REPORT' &&
 					deviceOptions.hasOwnProperty(node.device_data.token)) {
 					// Trigger on/off flows
-					if (report['Value (Raw)'][0] > 0 && deviceOptions[node.device_data.token].colorCache.r === 0) { Homey.manager('flow').triggerDevice('RGBW_input_on', null, { input: '1' }, node.device_data); }
+					if (report['Value (Raw)'][0] > 0 && deviceOptions[node.device_data.token].colorCache.r === 0) {
+						Homey.manager('flow').triggerDevice('RGBW_input_on', null, {
+							input: '1'
+						}, node.device_data);
+					}
 
-					if (report['Value (Raw)'][0] === 0) { Homey.manager('flow').triggerDevice('RGBW_input_off', null, { input: '1' }, node.device_data); }
+					if (report['Value (Raw)'][0] === 0) {
+						Homey.manager('flow').triggerDevice('RGBW_input_off', null, {
+							input: '1'
+						}, node.device_data);
+					}
 
 					// Update cache
 					deviceOptions[node.device_data.token].colorCache.r = (report['Value (Raw)'][0] || 0);
@@ -751,7 +818,9 @@ module.exports.on('initNode', token => {
 						module.exports.realtime(node.device_data, 'measure_voltage.input1', valueToVolt(report['Value (Raw)'][0]));
 						node.state['measure_voltage.input1'] = valueToVolt(report['Value (Raw)'][0]);
 						// Trigger any flows that are used
-						Homey.manager('flow').triggerDevice('RGBW_volt_input_1', { volt: valueToVolt(report['Value (Raw)'][0]) }, null, node.device_data);
+						Homey.manager('flow').triggerDevice('RGBW_volt_input_1', {
+							volt: valueToVolt(report['Value (Raw)'][0])
+						}, null, node.device_data);
 					}
 
 					// If not analog input(s), update values in homey
@@ -769,9 +838,17 @@ module.exports.on('initNode', token => {
 				if (command.name && command.name === 'SWITCH_MULTILEVEL_REPORT' &&
 					deviceOptions.hasOwnProperty(node.device_data.token)) {
 					// Trigger on/off flows
-					if (report['Value (Raw)'][0] > 0 && deviceOptions[node.device_data.token].colorCache.g === 0) { Homey.manager('flow').triggerDevice('RGBW_input_on', null, { input: '2' }, node.device_data); }
+					if (report['Value (Raw)'][0] > 0 && deviceOptions[node.device_data.token].colorCache.g === 0) {
+						Homey.manager('flow').triggerDevice('RGBW_input_on', null, {
+							input: '2'
+						}, node.device_data);
+					}
 
-					if (report['Value (Raw)'][0] === 0) { Homey.manager('flow').triggerDevice('RGBW_input_off', null, { input: '2' }, node.device_data); }
+					if (report['Value (Raw)'][0] === 0) {
+						Homey.manager('flow').triggerDevice('RGBW_input_off', null, {
+							input: '2'
+						}, node.device_data);
+					}
 
 					// Update cache
 					deviceOptions[node.device_data.token].colorCache.g = (report['Value (Raw)'][0] || 0);
@@ -782,7 +859,9 @@ module.exports.on('initNode', token => {
 						module.exports.realtime(node.device_data, 'measure_voltage.input2', valueToVolt(report['Value (Raw)'][0]));
 						node.state['measure_voltage.input2'] = valueToVolt(report['Value (Raw)'][0]);
 						// Trigger any flows that are used
-						Homey.manager('flow').triggerDevice('RGBW_volt_input_2', { volt: valueToVolt(report['Value (Raw)'][0]) }, null, node.device_data);
+						Homey.manager('flow').triggerDevice('RGBW_volt_input_2', {
+							volt: valueToVolt(report['Value (Raw)'][0])
+						}, null, node.device_data);
 					}
 
 					// If not analog input(s), update values in homey
@@ -800,9 +879,17 @@ module.exports.on('initNode', token => {
 				if (command.name && command.name === 'SWITCH_MULTILEVEL_REPORT' &&
 					deviceOptions.hasOwnProperty(node.device_data.token)) {
 					// Trigger on/off flows
-					if (report['Value (Raw)'][0] > 0 && deviceOptions[node.device_data.token].colorCache.b === 0) { Homey.manager('flow').triggerDevice('RGBW_input_on', null, { input: '3' }, node.device_data); }
+					if (report['Value (Raw)'][0] > 0 && deviceOptions[node.device_data.token].colorCache.b === 0) {
+						Homey.manager('flow').triggerDevice('RGBW_input_on', null, {
+							input: '3'
+						}, node.device_data);
+					}
 
-					if (report['Value (Raw)'][0] === 0) { Homey.manager('flow').triggerDevice('RGBW_input_off', null, { input: '3' }, node.device_data); }
+					if (report['Value (Raw)'][0] === 0) {
+						Homey.manager('flow').triggerDevice('RGBW_input_off', null, {
+							input: '3'
+						}, node.device_data);
+					}
 
 					// Update cache
 					deviceOptions[node.device_data.token].colorCache.b = (report['Value (Raw)'][0] || 0);
@@ -813,7 +900,9 @@ module.exports.on('initNode', token => {
 						module.exports.realtime(node.device_data, 'measure_voltage.input3', valueToVolt(report['Value (Raw)'][0]));
 						node.state['measure_voltage.input3'] = valueToVolt(report['Value (Raw)'][0]);
 						// Trigger any flows that are used
-						Homey.manager('flow').triggerDevice('RGBW_volt_input_3', { volt: valueToVolt(report['Value (Raw)'][0]) }, null, node.device_data);
+						Homey.manager('flow').triggerDevice('RGBW_volt_input_3', {
+							volt: valueToVolt(report['Value (Raw)'][0])
+						}, null, node.device_data);
 					}
 
 					// If not analog input(s), update values in homey
@@ -831,9 +920,17 @@ module.exports.on('initNode', token => {
 				if (command.name && command.name === 'SWITCH_MULTILEVEL_REPORT' &&
 					deviceOptions.hasOwnProperty(node.device_data.token)) {
 					// Trigger on/off flows
-					if (report['Value (Raw)'][0] > 0 && deviceOptions[node.device_data.token].colorCache.w === 0) { Homey.manager('flow').triggerDevice('RGBW_input_on', null, { input: '4' }, node.device_data); }
+					if (report['Value (Raw)'][0] > 0 && deviceOptions[node.device_data.token].colorCache.w === 0) {
+						Homey.manager('flow').triggerDevice('RGBW_input_on', null, {
+							input: '4'
+						}, node.device_data);
+					}
 
-					if (report['Value (Raw)'][0] === 0) { Homey.manager('flow').triggerDevice('RGBW_input_off', null, { input: '4' }, node.device_data); }
+					if (report['Value (Raw)'][0] === 0) {
+						Homey.manager('flow').triggerDevice('RGBW_input_off', null, {
+							input: '4'
+						}, node.device_data);
+					}
 
 					// Update cache
 					deviceOptions[node.device_data.token].colorCache.w = (report['Value (Raw)'][0] || 0);
@@ -844,11 +941,15 @@ module.exports.on('initNode', token => {
 						module.exports.realtime(node.device_data, 'measure_voltage.input4', valueToVolt(report['Value (Raw)'][0]));
 						node.state['measure_voltage.input4'] = valueToVolt(report['Value (Raw)'][0]);
 						// Trigger any flows that are used
-						Homey.manager('flow').triggerDevice('RGBW_volt_input_4', { volt: valueToVolt(report['Value (Raw)'][0]) }, null, node.device_data);
+						Homey.manager('flow').triggerDevice('RGBW_volt_input_4', {
+							volt: valueToVolt(report['Value (Raw)'][0])
+						}, null, node.device_data);
 					}
 
 					// If cct, update values in homey
-					else if (deviceOptions[node.device_data.token].stripType === 'cct') { updateValues(node); }
+					else if (deviceOptions[node.device_data.token].stripType === 'cct') {
+						updateValues(node);
+					}
 				}
 			});
 		}
@@ -916,13 +1017,19 @@ Homey.manager('flow').on('action.RGBW_specific', (callback, args) => {
 
 			// If single color is used, but not that color changed, stop flow card
 			if (deviceOptions[node.device_data.token].stripType.indexOf('sc') >= 0 &&
-				args.color !== deviceOptions[node.device_data.token].stripType.slice(2)) { return callback('Color not in use', false); }
+				args.color !== deviceOptions[node.device_data.token].stripType.slice(2)) {
+				return callback('Color not in use', false);
+			}
 
 			// If strip = CCT but the color is red or green, stop flow card
-			else if (deviceOptions[node.device_data.token].stripType === 'cct' && (args.color === 'r' || args.color === 'g')) { return callback('Color not in use', false); }
+			else if (deviceOptions[node.device_data.token].stripType === 'cct' && (args.color === 'r' || args.color === 'g')) {
+				return callback('Color not in use', false);
+			}
 
 			// If strip = RGB and color was white, stop flow card
-			else if (deviceOptions[node.device_data.token].stripType === 'rgb' && args.color === 'w') { return callback('Color not in use', false); }
+			else if (deviceOptions[node.device_data.token].stripType === 'rgb' && args.color === 'w') {
+				return callback('Color not in use', false);
+			}
 
 			sendColor([Math.round(args.brightness * 99)], [mc], node, (err, triggered) => callback(err, triggered));
 		} else return callback('No arguments found', false);
@@ -934,7 +1041,9 @@ Homey.manager('flow').on('action.RGBW_random', (callback, args) => {
 	const node = module.exports.nodes[args.device.token];
 
 	if (node && deviceOptions[node.device_data.token]) {
-		if (deviceOptions[node.device_data.token].stripType.indexOf('rgb') < 0) { return callback('Only available in RGB(W) mode', false); }
+		if (deviceOptions[node.device_data.token].stripType.indexOf('rgb') < 0) {
+			return callback('Only available in RGB(W) mode', false);
+		}
 
 		if (args && args.hasOwnProperty('range')) {
 			// Create a random RGB color on full saturation
@@ -953,18 +1062,27 @@ Homey.manager('flow').on('action.RGBW_random', (callback, args) => {
 
 			// Random RGB color WITH white
 			else if (args.range === 'rgbw') {
-				if (deviceOptions[node.device_data.token].stripType !== 'rgbw') { return callback('Only available on RGBW mode', false); }
+				if (deviceOptions[node.device_data.token].stripType !== 'rgbw') {
+					return callback('Only available on RGBW mode', false);
+				}
 
 				sendColor([rgb.r, rgb.g, rgb.b, (node.state.dim || 1) * 99], [2, 3, 4, 5], node, (err, triggered) => callback(err, triggered));
 			}
 
 			// Random RGB color OR white
 			else if (args.range === 'rgb-w') {
-				if (deviceOptions[node.device_data.token].stripType !== 'rgbw') { return callback('Only available on RGBW mode', false); }
+				if (deviceOptions[node.device_data.token].stripType !== 'rgbw') {
+					return callback('Only available on RGBW mode', false);
+				}
 
 				const option = Math.round(Math.random());
 
-				if (option !== 0) rgb = { r: 0, g: 0, b: 0, a: (node.state.dim * 99 || 99) };
+				if (option !== 0) rgb = {
+					r: 0,
+					g: 0,
+					b: 0,
+					a: (node.state.dim * 99 || 99)
+				};
 
 				sendColor([rgb.r, rgb.g, rgb.b, rgb.a], [2, 3, 4, 5], node, (err, triggered) => callback(err, triggered));
 			}
@@ -976,28 +1094,34 @@ Homey.manager('flow').on('action.RGBW_random', (callback, args) => {
 
 				// If it is an RGBW use one more option
 				if (args.range.indexOf('w') >= 0) {
-					if (deviceOptions[node.device_data.token].stripType !== 'rgbw') { return callback('Only available on RGBW mode', triggered); }
+					if (deviceOptions[node.device_data.token].stripType !== 'rgbw') {
+						return callback('Only available on RGBW mode', triggered);
+					}
 
 					option = Math.round(Math.random() * 4);
 				} else option = Math.round(Math.random() * 3);
 
 				switch (option) {
-					case 0: {
-						sendColor([99 * (node.state.dim || 1), 0, 0, 0], [2, 3, 4, 5], node, (err, triggered) => callback(err, triggered));
-						break;
-					}
-					case 1: {
-						sendColor([0, 99 * (node.state.dim || 1), 0, 0], [2, 3, 4, 5], node, (err, triggered) => callback(err, triggered));
-						break;
-					}
-					case 2: {
-						sendColor([0, 0, 99 * (node.state.dim || 1), 0], [2, 3, 4, 5], node, (err, triggered) => callback(err, triggered));
-						break;
-					}
-					case 3: {
-						sendColor([0, 0, 0, 99 * (node.state.dim || 1)], [2, 3, 4, 5], node, (err, triggered) => callback(err, triggered));
-						break;
-					}
+					case 0:
+						{
+							sendColor([99 * (node.state.dim || 1), 0, 0, 0], [2, 3, 4, 5], node, (err, triggered) => callback(err, triggered));
+							break;
+						}
+					case 1:
+						{
+							sendColor([0, 99 * (node.state.dim || 1), 0, 0], [2, 3, 4, 5], node, (err, triggered) => callback(err, triggered));
+							break;
+						}
+					case 2:
+						{
+							sendColor([0, 0, 99 * (node.state.dim || 1), 0], [2, 3, 4, 5], node, (err, triggered) => callback(err, triggered));
+							break;
+						}
+					case 3:
+						{
+							sendColor([0, 0, 0, 99 * (node.state.dim || 1)], [2, 3, 4, 5], node, (err, triggered) => callback(err, triggered));
+							break;
+						}
 				}
 			}
 
@@ -1008,40 +1132,49 @@ Homey.manager('flow').on('action.RGBW_random', (callback, args) => {
 
 				// If it is an RGBW use one more option
 				if (args.range.indexOf('w') >= 0) {
-					if (deviceOptions[node.device_data.token].stripType !== 'rgbw') { return callback('Only available on RGBW mode', triggered); }
+					if (deviceOptions[node.device_data.token].stripType !== 'rgbw') {
+						return callback('Only available on RGBW mode', triggered);
+					}
 
 					option = Math.round(Math.random() * 7);
 				} else option = Math.round(Math.random() * 6);
 
 				switch (option) {
-					case 0: {
-						sendColor([99 * (node.state.dim || 1), 0, 0, 0], [2, 3, 4, 5], node, (err, triggered) => callback(err, triggered));
-						break;
-					}
-					case 1: {
-						hue = 0.17;
-						break;
-					}
-					case 2: {
-						sendColor([0, 0, 99 * (node.state.dim || 1), 0], [2, 3, 4, 5], node, (err, triggered) => callback(err, triggered));
-						break;
-					}
-					case 3: {
-						hue = 0.50;
-						break;
-					}
-					case 4: {
-						sendColor([0, 0, 0, 99 * (node.state.dim || 1)], [2, 3, 4, 5], node, (err, triggered) => callback(err, triggered));
-						break;
-					}
-					case 5: {
-						hue = 0.83;
-						break;
-					}
-					case 6: {
-						sendColor([0, 0, 0, 99 * (node.state.dim || 1)], [2, 3, 4, 5], node, (err, triggered) => callback(err, triggered));
-						break;
-					}
+					case 0:
+						{
+							sendColor([99 * (node.state.dim || 1), 0, 0, 0], [2, 3, 4, 5], node, (err, triggered) => callback(err, triggered));
+							break;
+						}
+					case 1:
+						{
+							hue = 0.17;
+							break;
+						}
+					case 2:
+						{
+							sendColor([0, 0, 99 * (node.state.dim || 1), 0], [2, 3, 4, 5], node, (err, triggered) => callback(err, triggered));
+							break;
+						}
+					case 3:
+						{
+							hue = 0.50;
+							break;
+						}
+					case 4:
+						{
+							sendColor([0, 0, 0, 99 * (node.state.dim || 1)], [2, 3, 4, 5], node, (err, triggered) => callback(err, triggered));
+							break;
+						}
+					case 5:
+						{
+							hue = 0.83;
+							break;
+						}
+					case 6:
+						{
+							sendColor([0, 0, 0, 99 * (node.state.dim || 1)], [2, 3, 4, 5], node, (err, triggered) => callback(err, triggered));
+							break;
+						}
 				}
 
 				if (hue) {
@@ -1062,12 +1195,16 @@ Homey.manager('flow').on('action.RGBW_animation', (callback, args) => {
 	const node = module.exports.nodes[args.device.token];
 
 	if (node) {
-		if (deviceOptions[node.device_data.token].stripType.indexOf('rgb') < 0) { return callback('Only available in RGB(W) mode', false); }
+		if (deviceOptions[node.device_data.token].stripType.indexOf('rgb') < 0) {
+			return callback('Only available in RGB(W) mode', false);
+		}
 
 		if (deviceOptions[node.device_data.token].realInputConfig1 > 8 ||
 			deviceOptions[node.device_data.token].realInputConfig2 > 8 ||
 			deviceOptions[node.device_data.token].realInputConfig3 > 8 ||
-			deviceOptions[node.device_data.token].realInputConfig4 > 8) { return callback('Only available when no analog inputs are being used', false); }
+			deviceOptions[node.device_data.token].realInputConfig4 > 8) {
+			return callback('Only available when no analog inputs are being used', false);
+		}
 
 		if (args && args.hasOwnProperty('animation')) {
 			// If stop animation is choosen
@@ -1099,7 +1236,9 @@ Homey.manager('flow').on('action.RGBW_animation', (callback, args) => {
 					}
 
 					// If properly transmitted, change the setting and finish flow card
-					if (result === 'TRANSMIT_COMPLETE_OK') { return callback(null, true); }
+					if (result === 'TRANSMIT_COMPLETE_OK') {
+						return callback(null, true);
+					}
 
 					// No transmition, stop flow card
 					return callback('Transmition Failed', false);
@@ -1111,7 +1250,9 @@ Homey.manager('flow').on('action.RGBW_animation', (callback, args) => {
 
 function sendColor(values, multiChannels, node, callback) {
 	// Turn the device on if it is off, with sleep so only triggers once
-	if (!node.state.onoff || node.state.onoff === false) { node.state.onoff = true; }
+	if (!node.state.onoff || node.state.onoff === false) {
+		node.state.onoff = true;
+	}
 
 	if (typeof values === 'object' && typeof multiChannels === 'object') {
 		for (let i = 0; i < values.length; i++) {
@@ -1305,12 +1446,35 @@ function temperatureParser(value, dim) {
 Homey.manager('flow').on('trigger.RGBW_input_on', (callback, args, state) => {
 	if (args && args.hasOwnProperty('input') &&
 		state && state.hasOwnProperty('input') &&
-		args.input === state.input) { return callback(null, true); }
+		args.input === state.input) {
+		return callback(null, true);
+	}
 });
 
 Homey.manager('flow').on('trigger.RGBW_input_off', (callback, args, state) => {
 	if (args && args.hasOwnProperty('input') &&
 
 		state && state.hasOwnProperty('input') &&
-		args.input === state.input) { return callback(null, true); }
+		args.input === state.input) {
+		return callback(null, true);
+	}
+});
+
+Homey.manager('flow').on('action.FGRGBWM-441_reset_meter', (callback, args) => {
+	const node = module.exports.nodes[args.device.token];
+
+	if (node &&
+		node.instance.CommandClass.COMMAND_CLASS_METER) {
+		node.instance.CommandClass.COMMAND_CLASS_METER.METER_RESET({}, (err, result) => {
+			if (err) return callback(err);
+
+			// If properly transmitted, change the setting and finish flow card
+			if (result === 'TRANSMIT_COMPLETE_OK') {
+
+				return callback(null, true);
+			}
+
+			return callback('unknown_response');
+		});
+	} else return callback('unknown_error');
 });

--- a/drivers/FGRM-222/driver.js
+++ b/drivers/FGRM-222/driver.js
@@ -150,3 +150,22 @@ module.exports = new ZwaveDriver(path.basename(__dirname), {
 		invert_direction: (newValue, oldValue, deviceData) => module.exports.nodes[deviceData.token].settings.invert_direction = newValue
 	},
 });
+
+Homey.manager('flow').on('action.FGRM-222_reset_meter', (callback, args) => {
+	const node = module.exports.nodes[args.device.token];
+
+	if (node &&
+		node.instance.CommandClass.COMMAND_CLASS_METER) {
+		node.instance.CommandClass.COMMAND_CLASS_METER.METER_RESET({}, (err, result) => {
+			if (err) return callback(err);
+
+			// If properly transmitted, change the setting and finish flow card
+			if (result === 'TRANSMIT_COMPLETE_OK') {
+
+				return callback(null, true);
+			}
+
+			return callback('unknown_response');
+		});
+	} else return callback('unknown_error');
+});

--- a/drivers/FGS-213/driver.js
+++ b/drivers/FGS-213/driver.js
@@ -110,11 +110,17 @@ module.exports.on('initNode', token => {
 							report.Properties1.hasOwnProperty('Key Attributes') &&
 							report.hasOwnProperty('Scene Number')) {
 
-							const data = { scene: report.Properties1['Key Attributes'] };
+							const data = {
+								scene: report.Properties1['Key Attributes']
+							};
 
-							if (report['Scene Number'] === 1) { Homey.manager('flow').triggerDevice('FGS-213_S1', null, data, node.device_data); }
+							if (report['Scene Number'] === 1) {
+								Homey.manager('flow').triggerDevice('FGS-213_S1', null, data, node.device_data);
+							}
 
-							if (report['Scene Number'] === 2) { Homey.manager('flow').triggerDevice('FGS-213_S2', null, data, node.device_data); }
+							if (report['Scene Number'] === 2) {
+								Homey.manager('flow').triggerDevice('FGS-213_S2', null, data, node.device_data);
+							}
 						}
 					}
 				});
@@ -131,4 +137,23 @@ Homey.manager('flow').on('trigger.FGS-213_S1', (callback, args, state) => {
 Homey.manager('flow').on('trigger.FGS-213_S2', (callback, args, state) => {
 	if (state.scene === args.scene) return callback(null, true);
 	return callback(null, false);
+});
+
+Homey.manager('flow').on('action.FGS-213_reset_meter', (callback, args) => {
+	const node = module.exports.nodes[args.device.token];
+
+	if (node &&
+		node.instance.CommandClass.COMMAND_CLASS_METER) {
+		node.instance.CommandClass.COMMAND_CLASS_METER.METER_RESET({}, (err, result) => {
+			if (err) return callback(err);
+
+			// If properly transmitted, change the setting and finish flow card
+			if (result === 'TRANSMIT_COMPLETE_OK') {
+
+				return callback(null, true);
+			}
+
+			return callback('unknown_response');
+		});
+	} else return callback('unknown_error');
 });

--- a/drivers/FGS-223/driver.js
+++ b/drivers/FGS-223/driver.js
@@ -129,16 +129,22 @@ module.exports.on('initNode', token => {
 							report.Properties1.hasOwnProperty('Key Attributes') &&
 							report.hasOwnProperty('Scene Number')) {
 
-							const data = { scene: report.Properties1['Key Attributes'] };
+							const data = {
+								scene: report.Properties1['Key Attributes']
+							};
 
-							if (report['Scene Number'] === 1) { Homey.manager('flow').triggerDevice('FGS-223_S1', null, data, node.device_data); }
+							if (report['Scene Number'] === 1) {
+								Homey.manager('flow').triggerDevice('FGS-223_S1', null, data, node.device_data);
+							}
 
 							if (report['Scene Number'] === 2) {
 								Homey.manager('flow').triggerDevice('FGS-223_S2', null, data, node.device_data);
 
 								// Also GET state S2, not reported automatically
 								setTimeout(() => {
-									if (typeof node.instance.MultiChannelNodes[2] !== 'undefined') { node.instance.MultiChannelNodes[2].CommandClass.COMMAND_CLASS_SWITCH_BINARY.SWITCH_BINARY_GET(); }
+									if (typeof node.instance.MultiChannelNodes[2] !== 'undefined') {
+										node.instance.MultiChannelNodes[2].CommandClass.COMMAND_CLASS_SWITCH_BINARY.SWITCH_BINARY_GET();
+									}
 								}, 500);
 							}
 						}
@@ -157,4 +163,23 @@ Homey.manager('flow').on('trigger.FGS-223_S1', (callback, args, state) => {
 Homey.manager('flow').on('trigger.FGS-223_S2', (callback, args, state) => {
 	if (state.scene === args.scene) return callback(null, true);
 	return callback(null, false);
+});
+
+Homey.manager('flow').on('action.FGS-223_reset_meter', (callback, args) => {
+	const node = module.exports.nodes[args.device.token];
+
+	if (node &&
+		node.instance.CommandClass.COMMAND_CLASS_METER) {
+		node.instance.CommandClass.COMMAND_CLASS_METER.METER_RESET({}, (err, result) => {
+			if (err) return callback(err);
+
+			// If properly transmitted, change the setting and finish flow card
+			if (result === 'TRANSMIT_COMPLETE_OK') {
+
+				return callback(null, true);
+			}
+
+			return callback('unknown_response');
+		});
+	} else return callback('unknown_error');
 });

--- a/drivers/FGWPx-102-PLUS/driver.js
+++ b/drivers/FGWPx-102-PLUS/driver.js
@@ -32,7 +32,9 @@ module.exports = new ZwaveDriver(path.basename(__dirname), {
 				if (report['Sensor Type'] === 'Power (version 2)' &&
 					report.hasOwnProperty('Level') &&
 					report.Level.hasOwnProperty('Scale') &&
-					report.Level.Scale === 0) { return report['Sensor Value (Parsed)']; }
+					report.Level.Scale === 0) {
+					return report['Sensor Value (Parsed)'];
+				}
 
 				return null;
 			},
@@ -50,7 +52,9 @@ module.exports = new ZwaveDriver(path.basename(__dirname), {
 			command_report_parser: report => {
 				if (report.hasOwnProperty('Properties2') &&
 					report.Properties2.hasOwnProperty('Scale') &&
-					report.Properties2.Scale === 0) { return report['Meter Value (Parsed)']; }
+					report.Properties2.Scale === 0) {
+					return report['Meter Value (Parsed)'];
+				}
 
 				return null;
 			},
@@ -183,4 +187,24 @@ Homey.manager('flow').on('action.FGWPx-102-PLUS_led_off', (callback, args) => {
 	}
 
 	return callback(null, false);
+});
+
+
+Homey.manager('flow').on('action.FGWPx-102-PLUS_reset_meter', (callback, args) => {
+	const node = module.exports.nodes[args.device.token];
+
+	if (node &&
+		node.instance.CommandClass.COMMAND_CLASS_METER) {
+		node.instance.CommandClass.COMMAND_CLASS_METER.METER_RESET({}, (err, result) => {
+			if (err) return callback(err);
+
+			// If properly transmitted, change the setting and finish flow card
+			if (result === 'TRANSMIT_COMPLETE_OK') {
+
+				return callback(null, true);
+			}
+
+			return callback('unknown_response');
+		});
+	} else return callback('unknown_error');
 });


### PR DESCRIPTION
Changelog (updated in readme)
### v 1.3.2
**fixed:**
FGD-211, FGD-212: dimmer on/off state not updated
**update:**
FGD-212, FGRGBWM-441, FGRM-222, FGS-2x3, FGWPE-101, FGWPx-102-PLUS: add
power meter reset flow card
FGD-212: add set timer flow card

**fixed:**
FGD-211, FGD-212: dimmer on/off state not updated
- since setting `"setOnDim": false` on/off state of dimmer (FGD-211 and
FGD-212) where not always updated correctly; re-used code of FGRGBWM-441

FGD-212, FGRGBWM-441, FGRM-222, FGS-2x3, FGWPE-101, FGWPx-102-PLUS: add
power meter reset flow card
- Added power_meter reset card for all devices with meter_power
capability

FGD-212: add set timer flow card
- added set timer parameter flow card

Minor updates (not in change log):
FGD-212: bug fixes
- Input validation of “forced brightness level property” positioned at
“dim_duration” function
- Input validation of “dim_duration” extended with brightness_level
check
- Validations verified at own setup

FGMS-001-PLUS
- removed debug: true