### PR TITLE
FGRM-222: add initial scene support

### DIFF
--- a/app.json
+++ b/app.json
@@ -1406,6 +1406,218 @@
         ]
       },
       {
+        "id": "FGRM-222-momentary",
+        "title": {
+          "en": "Shutter scene (momentary)",
+          "nl": "Rolluik scene (pulsdruk)"
+        },
+        "hint": {
+          "en": "This card will only get triggered if the setting Switch type: \"Momentary\" is selected.",
+          "nl": "Deze kaart wordt alleen geactiveerd als de instelling Schakelaar type: \"Pulsdruk\" is geselecteerd."
+        },
+        "args": [
+          {
+            "name": "device",
+            "type": "device",
+            "filter": "driver_id=FGRM-222"
+          },
+          {
+            "name": "scene",
+            "type": "dropdown",
+            "values": [
+              {
+                "id": "12",
+                "label": {
+                  "en": "Long press left (S1)",
+                  "nl": "Links (S1) lang drukken"
+                }
+              },
+              {
+                "id": "13",
+                "label": {
+                  "en": "Long press left (S1) released",
+                  "nl": "Links (S1) lang drukken gestopt"
+                }
+              },
+              {
+                "id": "14",
+                "label": {
+                  "en": "Pressed left (S1) 2x",
+                  "nl": "Links (S1) 2x ingedrukt"
+                }
+              },
+              {
+                "id": "16",
+                "label": {
+                  "en": "Pressed left (S1) 1x",
+                  "nl": "Links (S1) 1x ingedrukt"
+                }
+              },
+              {
+                "id": "22",
+                "label": {
+                  "en": "Long press right (S2)",
+                  "nl": "Rechts (S2) lang drukken"
+                }
+              },
+              {
+                "id": "23",
+                "label": {
+                  "en": "Long press right (S2) released",
+                  "nl": "Rechts (S2) lang drukken gestopt"
+                }
+              },
+              {
+                "id": "24",
+                "label": {
+                  "en": "Pressed right (S2) 2x",
+                  "nl": "Rechts (S2) 2x ingedrukt"
+                }
+              },
+              {
+                "id": "25",
+                "label": {
+                  "en": "Pressed right (S2) 3x",
+                  "nl": "Rechts (S2) 3x ingedrukt"
+                }
+              },
+              {
+                "id": "26",
+                "label": {
+                  "en": "Pressed right (S2) 1x",
+                  "nl": "Rechts (S2) 1x ingedrukt"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "id": "FGRM-222-toggle",
+        "title": {
+          "en": "Shutter scene (toggle)",
+          "nl": "Rolluik scene (tuimel)"
+        },
+        "hint": {
+          "en": "This card will only get triggered if the setting Switch type: \"Toggle\" is selected.",
+          "nl": "Deze kaart wordt alleen geactiveerd als de instelling Schakelaar type: \"Tuimel\" is geselecteerd."
+        },
+        "args": [
+          {
+            "name": "device",
+            "type": "device",
+            "filter": "driver_id=FGRM-222"
+          },
+          {
+            "name": "scene",
+            "type": "dropdown",
+            "values": [
+              {
+                "id": "10",
+                "label": {
+                  "en": "Left (S1) off to on *",
+                  "nl": "Links (S1) uit naar aan *"
+                }
+              },
+              {
+                "id": "11",
+                "label": {
+                  "en": "Left (S1) on to off *",
+                  "nl": "Links (S1) aan naar uit *"
+                }
+              },
+              {
+                "id": "14",
+                "label": {
+                  "en": "Switched left (S1) 2x",
+                  "nl": "Links (S1) 2x geschakeld"
+                }
+              },
+              {
+                "id": "20",
+                "label": {
+                  "en": "Right (S2) off to on *",
+                  "nl": "Rechts (S2) uit naar aan *"
+                }
+              },
+              {
+                "id": "21",
+                "label": {
+                  "en": "Right (S2) on to off *",
+                  "nl": "Rechts (S2) aan naar uit *"
+                }
+              },
+              {
+                "id": "24",
+                "label": {
+                  "en": "Switched right (S2) 2x",
+                  "nl": "Rechts (S2) 2x geschakeld"
+                }
+              },
+              {
+                "id": "25",
+                "label": {
+                  "en": "Switched right (S2) 3x",
+                  "nl": "Rechts (S2) 3x geschakeld"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "id": "FGRM-222-momentary_single-gate_switch",
+        "title": {
+          "en": "Shutter scene (Single momentary/Gate)",
+          "nl": "Rolluik scene (Enkele pulsedruk/Poort)"
+        },
+        "hint": {
+          "en": "This card will only get triggered if the setting Switch type is \"Single momentary\" or \"Gate mode\" is selected.",
+          "nl": "Deze kaart wordt alleen geactiveerd als de instelling Schakelaar type: \"Enkele pulsdruk\" is geselecteerd."
+        },
+        "args": [
+          {
+            "name": "device",
+            "type": "device",
+            "filter": "driver_id=FGRM-222"
+          },
+          {
+            "name": "scene",
+            "type": "dropdown",
+            "values": [
+              {
+                "id": "12",
+                "label": {
+                  "en": "Long press left (S1)",
+                  "nl": "Links (S1) lang drukken"
+                }
+              },
+              {
+                "id": "13",
+                "label": {
+                  "en": "Long press left (S1) released",
+                  "nl": "Links (S1) lang drukken gestopt"
+                }
+              },
+              {
+                "id": "14",
+                "label": {
+                  "en": "Pressed 2x left (S1)",
+                  "nl": "2x ingedrukt links (S1)"
+                }
+              },
+              {
+                "id": "16",
+                "label": {
+                  "en": "Pressed left (S1) 1x",
+                  "nl": "Links (S1) 1x ingedrukt"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      {
         "id": "FGS-213_S1",
         "title": {
           "en": "Left Switch (S1)",
@@ -8656,6 +8868,29 @@
             "nl": "Keer rolluik beweging om"
           },
           "value": false
+        },
+        {
+          "id": "scenes_and_associations",
+          "type": "dropdown",
+          "label": {
+            "en": "Scenes or associations mode",
+            "nl": "Scene of associatie modus"
+          },
+          "value": "0",
+          "values": [
+            {
+              "id": "0",
+              "label": {
+                "en": "Associations activation"
+              }
+            },
+            {
+              "id": "1",
+              "label": {
+                "en": "Scenes activation"
+              }
+            }
+          ]
         }
       ]
     },

--- a/config/drivers/FGRM-222.json
+++ b/config/drivers/FGRM-222.json
@@ -219,7 +219,7 @@
 			"id": "scenes_and_associations",
 			"type": "dropdown",
 			"label": {
-				"en": "Scenes or associations mode",
+				"en": "Scene or association mode",
 				"nl": "Scene of associatie modus"
 			},
 			"value": "0",
@@ -227,13 +227,13 @@
 				{
 					"id": "0",
 					"label": {
-						"en": "Associations activation"
+						"en": "Association activated"
 					}
 				},
 				{
 					"id": "1",
 					"label": {
-						"en": "Scenes activation"
+						"en": "Scenes activated"
 					}
 				}
 			]

--- a/config/drivers/FGRM-222.json
+++ b/config/drivers/FGRM-222.json
@@ -214,6 +214,29 @@
 				"nl": "Keer rolluik beweging om"
 			},
 			"value": false
+		},
+		{
+			"id": "scenes_and_associations",
+			"type": "dropdown",
+			"label": {
+				"en": "Scenes or associations mode",
+				"nl": "Scene of associatie modus"
+			},
+			"value": "0",
+			"values": [
+				{
+					"id": "0",
+					"label": {
+						"en": "Associations activation"
+					}
+				},
+				{
+					"id": "1",
+					"label": {
+						"en": "Scenes activation"
+					}
+				}
+			]
 		}
 	]
 }

--- a/config/flow/triggers/FGRM-222.json
+++ b/config/flow/triggers/FGRM-222.json
@@ -1,0 +1,214 @@
+[
+	{
+		"id": "FGRM-222-momentary",
+		"title": {
+			"en": "Shutter scene (momentary)",
+			"nl": "Rolluik scene (pulsdruk)"
+		},
+		"hint": {
+			"en": "This card will only get triggered if the setting Switch type: \"Momentary\" is selected.",
+			"nl": "Deze kaart wordt alleen geactiveerd als de instelling Schakelaar type: \"Pulsdruk\" is geselecteerd."
+		},
+		"args": [
+			{
+				"name": "device",
+				"type": "device",
+				"filter": "driver_id=FGRM-222"
+			},
+			{
+				"name": "scene",
+				"type": "dropdown",
+				"values": [
+					{
+						"id": "12",
+						"label": {
+							"en": "Long press left (S1)",
+							"nl": "Links (S1) lang drukken"
+						}
+					},
+					{
+						"id": "13",
+						"label": {
+							"en": "Long press left (S1) released",
+							"nl": "Links (S1) lang drukken gestopt"
+						}
+					},
+					{
+						"id": "14",
+						"label": {
+							"en": "Pressed left (S1) 2x",
+							"nl": "Links (S1) 2x ingedrukt"
+						}
+					},
+					{
+						"id": "16",
+						"label": {
+							"en": "Pressed left (S1) 1x",
+							"nl": "Links (S1) 1x ingedrukt"
+						}
+					},
+					{
+						"id": "22",
+						"label": {
+							"en": "Long press right (S2)",
+							"nl": "Rechts (S2) lang drukken"
+						}
+					},
+					{
+						"id": "23",
+						"label": {
+							"en": "Long press right (S2) released",
+							"nl": "Rechts (S2) lang drukken gestopt"
+						}
+					},
+					{
+						"id": "24",
+						"label": {
+							"en": "Pressed right (S2) 2x",
+							"nl": "Rechts (S2) 2x ingedrukt"
+						}
+					},
+					{
+						"id": "25",
+						"label": {
+							"en": "Pressed right (S2) 3x",
+							"nl": "Rechts (S2) 3x ingedrukt"
+						}
+					},
+					{
+						"id": "26",
+						"label": {
+							"en": "Pressed right (S2) 1x",
+							"nl": "Rechts (S2) 1x ingedrukt"
+						}
+					}
+				]
+			}
+		]
+	},
+	{
+		"id": "FGRM-222-toggle",
+		"title": {
+			"en": "Shutter scene (toggle)",
+			"nl": "Rolluik scene (tuimel)"
+		},
+		"hint": {
+			"en": "This card will only get triggered if the setting Switch type: \"Toggle\" is selected.",
+			"nl": "Deze kaart wordt alleen geactiveerd als de instelling Schakelaar type: \"Tuimel\" is geselecteerd."
+		},
+		"args": [
+			{
+				"name": "device",
+				"type": "device",
+				"filter": "driver_id=FGRM-222"
+			},
+			{
+				"name": "scene",
+				"type": "dropdown",
+				"values": [
+					{
+						"id": "10",
+						"label": {
+							"en": "Left (S1) off to on *",
+							"nl": "Links (S1) uit naar aan *"
+						}
+					},
+					{
+						"id": "11",
+						"label": {
+							"en": "Left (S1) on to off *",
+							"nl": "Links (S1) aan naar uit *"
+						}
+					},
+					{
+						"id": "14",
+						"label": {
+							"en": "Switched left (S1) 2x",
+							"nl": "Links (S1) 2x geschakeld"
+						}
+					},
+					{
+						"id": "20",
+						"label": {
+							"en": "Right (S2) off to on *",
+							"nl": "Rechts (S2) uit naar aan *"
+						}
+					},
+					{
+						"id": "21",
+						"label": {
+							"en": "Right (S2) on to off *",
+							"nl": "Rechts (S2) aan naar uit *"
+						}
+					},
+					{
+						"id": "24",
+						"label": {
+							"en": "Switched right (S2) 2x",
+							"nl": "Rechts (S2) 2x geschakeld"
+						}
+					},
+					{
+						"id": "25",
+						"label": {
+							"en": "Switched right (S2) 3x",
+							"nl": "Rechts (S2) 3x geschakeld"
+						}
+					}
+				]
+			}
+		]
+	},
+	{
+		"id": "FGRM-222-momentary_single-gate_switch",
+		"title": {
+			"en": "Shutter scene (Single momentary/Gate)",
+			"nl": "Rolluik scene (Enkele pulsedruk/Poort)"
+		},
+		"hint": {
+			"en": "This card will only get triggered if the setting Switch type is \"Single momentary\" or \"Gate mode\" is selected.",
+			"nl": "Deze kaart wordt alleen geactiveerd als de instelling Schakelaar type: \"Enkele pulsdruk\" of \"Poort mode\" is geselecteerd."
+		},
+		"args": [
+			{
+				"name": "device",
+				"type": "device",
+				"filter": "driver_id=FGRM-222"
+			},
+			{
+				"name": "scene",
+				"type": "dropdown",
+				"values": [
+					{
+						"id": "12",
+						"label": {
+							"en": "Long press left (S1)",
+							"nl": "Links (S1) lang drukken"
+						}
+					},
+					{
+						"id": "13",
+						"label": {
+							"en": "Long press left (S1) released",
+							"nl": "Links (S1) lang drukken gestopt"
+						}
+					},
+					{
+						"id": "14",
+						"label": {
+							"en": "Pressed 2x left (S1)",
+							"nl": "2x ingedrukt links (S1)"
+						}
+					},
+					{
+						"id": "16",
+						"label": {
+							"en": "Pressed left (S1) 1x",
+							"nl": "Links (S1) 1x ingedrukt"
+						}
+					}
+				]
+			}
+		]
+	}
+]


### PR DESCRIPTION
This should add basic scene support for FGRM-222 shutter module.
It introduces another setting to toggle parameter 50 (scene support).

It should not be that hard to copy this functionality to the FGR-222 module which is basically the same.