### PR TITLE
FGRM-222: automatic uncheck of calibration setting

### DIFF
--- a/drivers/FGRM-222/driver.js
+++ b/drivers/FGRM-222/driver.js
@@ -146,6 +146,16 @@ module.exports = new ZwaveDriver(path.basename(__dirname), {
 		start_calibration: {
 			index: 29,
 			size: 1,
+			parser: (newValue, newSettings, deviceData) => {
+				setTimeout(() => {
+					module.exports.setSettings(deviceData, {
+						start_calibration: false,
+					}, (err) => {
+						if (err) console.error('Failed to revert setting', err);
+					});
+				}, 3000);
+				return new Buffer([(newValue === true) ? 1 : 0]);
+			},
 		},
 		invert_direction: (newValue, oldValue, deviceData) => module.exports.nodes[deviceData.token].settings.invert_direction = newValue
 	},


### PR DESCRIPTION
I was looking into getting this functionality included in the zwave-driver and introduce a new setting option in the driver.js zwave settings called `{ reset: 5 }` where 5 would be the timeout after the settings would be reset/reverted, but i couldnt find a way how to update driver settings within the zwave-driver.
As a second option one could introduce a new emitter in the zwave-driver and add a listening in driver.js and trigger an update of its settings, but in the end the parser method seems the easiest for now, or somebody else would need to provide an alternative.

If this is the proper way, we could add this piece of code to more drivers/apps that have calibration options to prevent users from forgetting to unset this option and get a new calibration on settings save. 
