### PR TITLE
Added new product ID to z-wave plus wallplug

### DIFF
--- a/app.json
+++ b/app.json
@@ -3,7 +3,7 @@
   "name": {
     "en": "Fibaro"
   },
-  "version": "1.5.17",
+  "version": "1.5.18",
   "compatibility": ">=1.3.0",
   "description": {
     "en": "Fibaro devices for Homey"
@@ -11736,6 +11736,7 @@
         "productTypeId": 1538,
         "productId": [
           4097,
+          4099,
           8193,
           12289
         ],


### PR DESCRIPTION
Quick hot fix as a user ran into "Unknown Z-Wave device" and the productID was not in the list of possible IDs