### PR TITLE
FGT-001: Add thermostat_mode capability

### DIFF
--- a/drivers/FGT-001/device.js
+++ b/drivers/FGT-001/device.js
@@ -6,26 +6,89 @@ const ZwaveDevice = require('homey-meshdriver').ZwaveDevice;
 class RadiatorThermostat extends ZwaveDevice {
 
 	onMeshInit() {
+
+        this.registerCapability('thermostat_mode', 'THERMOSTAT_MODE', {
+            get: 'THERMOSTAT_MODE_GET',
+            getOpts: {
+                pollInterval: 'poll_interval_thermostat_mode',
+                pollMultiplication: 1000,
+                getOnOnline: true
+            },
+			report: 'THERMOSTAT_MODE_REPORT',
+            reportParserV2: report => {
+                if (!report) return null;
+                if (report.hasOwnProperty('Level') && report.Level.hasOwnProperty('Mode')) {
+                    return this.heatModeMap(report.Level.Mode);
+                }
+                return null;
+            },
+            set: 'THERMOSTAT_MODE_SET',
+            setParserV2: value => {
+                let mode = this.heatModeMap(value, true);
+                return {
+                    Level: {
+                        'No of Manufacturer Data fields': 0,
+                        Mode: mode,
+                    },
+                    'Manufacturer Data': new Buffer([0])
+                };
+            }
+        });
+
 		this.registerCapability('measure_battery', 'BATTERY', {
 			getOpts: {
 				pollInterval: 'poll_interval_battery',
-				pollMultiplication: 1000,
-			},
+				pollMultiplication: 1000
+			}
 		});
-		this.registerCapability('measure_temperature', 'SENSOR_MULTILEVEL', {
-        	getOpts: {
-        		pollInterval: 'poll_interval_measure_temperature',
-				pollMultiplication: 1000,
-			},
-		});
+
+        this.registerCapability('measure_temperature', 'SENSOR_MULTILEVEL', {
+            getOpts: {
+                pollInterval: 'poll_interval_measure_temperature',
+                pollMultiplication: 1000,
+            },
+        });
+
 		this.registerCapability('target_temperature', 'THERMOSTAT_SETPOINT', {
 			getOpts: {
 				pollInterval: 'poll_interval_target_temperature',
 				pollMultiplication: 1000,
+                getOnOnline: true
 			},
+            report: 'THERMOSTAT_SETPOINT_REPORT',
+            set: 'THERMOSTAT_SETPOINT_SET'
 		});
 	}
 
+    heatModeMap (value, set) {
+	    let mode = null;
+
+	    if (set) {
+            if (value === 'heat') {
+                // Heat best matches fully open valve
+                mode = 'MANUFACTURER SPECIFC';
+            } else if (value === 'cool' || value === 'off') {
+                // Cool and off best matches 'off'
+                mode = 'Off';
+            } else {
+                // Follow setpoint temperature
+                mode = 'Heat';
+            }
+        } else {
+            if (value === 'MANUFACTURER SPECIFC') {
+                // Valve fully opened
+                mode = 'heat';
+            } else if (value === 'Heat') {
+                // Following setpoint temperature
+                mode = 'auto';
+            } else if (value === 'Off') {
+                // Valve fully closed
+                mode = 'off';
+            }
+        }
+
+        return mode;
+    }
 }
 
 module.exports = RadiatorThermostat;

--- a/drivers/FGT-001/driver.compose.json
+++ b/drivers/FGT-001/driver.compose.json
@@ -1,14 +1,15 @@
 {
   "id": "FGT-001",
   "name": {
-    "en": "Radiator Thermostat",
-    "nl": "Radiator Thermostaat"
+    "en": "Thermostatic Radiator Head",
+    "nl": "Thermostaatkop"
   },
   "class": "thermostat",
   "capabilities": [
     "measure_battery",
     "target_temperature",
-    "measure_temperature"
+    "measure_temperature",
+    "thermostat_mode"
   ],
   "images": {
     "large": "{{driverAssetsPath}}/images/large.jpg",

--- a/drivers/FGT-001/driver.settings.compose.json
+++ b/drivers/FGT-001/driver.settings.compose.json
@@ -49,5 +49,22 @@
       "en": "The amount of seconds between asking the device for its target temperature.",
       "nl": "Aantal seconden tussen het opvragen van de doel temperatuur aan het apparaat."
     }
+  },
+  {
+    "id": "poll_interval_thermostat_mode",
+    "type": "number",
+    "attr": {
+      "min": 60,
+      "max": 86400
+    },
+    "value": 600,
+    "label": {
+      "en": "Thermostat mode poll interval",
+      "nl": "Thermostaat mode poll interval"
+    },
+    "hint": {
+      "en": "The amount of seconds between asking the device for its current thermostat mode.",
+      "nl": "Aantal seconden tussen het opvragen van huidige thermostaat mode aan het apparaat."
+    }
   }
 ]


### PR DESCRIPTION
Adds thermostat mode picker to FGT-001 devices.

As requested in #223. Added mode because without mode, the Fibaro Thermostat Head is not really usable in any bedroom as there is no way to disable its noisy escapades through the night without manually turning it completely closed or open.

This implementation aims to keep the default capabilities in place as much as possible. Tested from app and with HomeKit, seems to work fine. Currently, 'Heating' will fully open the valve, 'Cooling' and 'Off' will fully close it, 'Auto' will follow setpoint temperature. If any changes in this behaviour are needed, please do so at your discretion.