### PR TITLE
Fix (optional) temperature sensor FGK-101

### DIFF
--- a/drivers/FGK-101/device.js
+++ b/drivers/FGK-101/device.js
@@ -16,6 +16,7 @@ class FibaroDoorSensor extends ZwaveDevice {
 			},
 		});
 		this.registerCapability('measure_temperature', 'SENSOR_MULTILEVEL', {
+			multiChannelNodeId: 2,
 			getOnStart: false,
 		});
 		this.registerCapability('measure_battery', 'BATTERY');


### PR DESCRIPTION
The FGK-101 sends out its temperature report from endpoint 2, but this wasn't specified in the driver.
This will fix it.

Tested, see [forum post](https://community.athom.com/t/13364/)

And from before the rewrite, where it was still there (and worked):
https://github.com/athombv/com.fibaro/blob/0c41448281d71a7fca6782c0923520849327416b/drivers/FGK-101/driver.js#L59