### PR TITLE
fix for issues regarding the white channel for FGRGBWM-441

### DIFF
--- a/drivers/FGRGBWM-441/device.js
+++ b/drivers/FGRGBWM-441/device.js
@@ -219,8 +219,8 @@ class FibaroRGBWControllerDevice extends ZwaveDevice {
 
         Object.keys(colorObject).forEach(async (key) => {
             this.log(`Sending value: ${colorObject[key]} to node: ${multiChannelNodeToColorMap[key]}`);
-            // Get the node matching with the color, then send the color value divided by 2.55 (0-100 range)
-            await this.node.MultiChannelNodes[multiChannelNodeToColorMap[key]].CommandClass.COMMAND_CLASS_SWITCH_MULTILEVEL.SWITCH_MULTILEVEL_SET({Value: Math.round(colorObject[key] /2.55)});
+            // Get the node matching with the color, then send the color value divided by 2.55 (0-99 range)
+            await this.node.MultiChannelNodes[multiChannelNodeToColorMap[key]].CommandClass.COMMAND_CLASS_SWITCH_MULTILEVEL.SWITCH_MULTILEVEL_SET({Value: Math.round((colorObject[key] / 255)*99)});
         });
         return true;
     }


### PR DESCRIPTION
2 fixes:
- The max value for SWITCH_MULTILEVEL is 99 instead of 100. So 100 value (for full on) is ignored by the controller.
- convertRGBToHSV does not use the white led value, so when only the white led is on, the dim value is set to 0 when Report for multiChannelNode is send from the controller.