### PR TITLE
Fix displayed value for forced brightness of FGD-212

### DIFF
--- a/drivers/FGD-212/device.js
+++ b/drivers/FGD-212/device.js
@@ -50,11 +50,12 @@ class FibaroDimmerTwoDevice extends ZwaveDevice {
 		if (args.set_forced_brightness_level > 1) return Promise.reject('forced_brightness_level_out_of_range');
 
 		try {
+			let brightnessLevel = Math.round(args.set_forced_brightness_level * 99);
 			let result = await this.configurationSet({
 				id: 'forced_brightness_level'
-			}, Math.round(args.set_forced_brightness_level * 99));
+			}, brightnessLevel);
 			return this.setSettings({
-				'forced_brightness_level': args.set_forced_brightness_level
+				'forced_brightness_level': brightnessLevel 
 			});
 		}
 		catch (error) {


### PR DESCRIPTION
I found a small issue with a flow card for FGD-212 (Dimmer 2).

The flow card for forced brightness gets a floating point value between 0 and 1 (slider).
The value was correctly multiplied by 99 before setting the device configuration, but the displayed value in de device settings was not.

So for example, if I set brightness to 20%, the device settings would display `0.2`, while the scale of the parameter is `0` to `99`.